### PR TITLE
docs: point basic map example code link to matching url

### DIFF
--- a/examples/basic-map/src/control-panel.tsx
+++ b/examples/basic-map/src/control-panel.tsx
@@ -10,7 +10,7 @@ function ControlPanel() {
       </p>
       <div className="source-link">
         <a
-          href="https://github.com/visgl/react-google-maps/tree/main/examples/_template"
+          href="https://github.com/visgl/react-google-maps/tree/main/examples/basic-map"
           target="_new">
           View Code ↗
         </a>


### PR DESCRIPTION
- fix basic map example code link to point to the correct sub folder