### PR TITLE
docs: use correct package name in examples

### DIFF
--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -3,7 +3,7 @@
 The `APIProvider` is our component to load the Google Maps JavaScript API.
 
 This component can be added at any level of the application (typically somewhere
-at the top), and it will render all child components unmodified. 
+at the top), and it will render all child components unmodified.
 
 Besides handling the loading of the Maps JavaScript API, it also provides context
 information and functions for the other components and hooks of this library.
@@ -19,7 +19,7 @@ This has to be provided via the `apiKey` prop:
 
 ```tsx title="app.jsx"
 import React from 'react';
-import {APIProvider} from '@vis.gl/react-google-maps-components';
+import {APIProvider} from '@vis.gl/react-google-maps';
 
 const App = () => (
   <APIProvider apiKey={'Your API key here'}>

--- a/docs/api-reference/components/info-window.md
+++ b/docs/api-reference/components/info-window.md
@@ -19,11 +19,7 @@ with the map, you can listen for the `onCloseClick` event.
 
 ```tsx
 import React from 'react';
-import {
-  APIProvider,
-  Map,
-  InfoWindow
-} from '@vis.gl/react-google-maps-components';
+import {APIProvider, Map, InfoWindow} from '@vis.gl/react-google-maps';
 
 const App = () => (
   <APIProvider apiKey={'Your API key here'}>
@@ -47,7 +43,7 @@ import {
   Map,
   Marker,
   useMarkerRef
-} from '@vis.gl/react-google-maps-components';
+} from '@vis.gl/react-google-maps';
 
 const App = () => {
   const [markerRef, marker] = useMarkerRef();
@@ -81,7 +77,7 @@ import {
   Map,
   AdvancedMarker,
   useAdvancedMarkerRef
-} from '@vis.gl/react-google-maps-components';
+} from '@vis.gl/react-google-maps';
 
 const App = () => {
   const [markerRef, marker] = useAdvancedMarkerRef();

--- a/docs/api-reference/components/map.md
+++ b/docs/api-reference/components/map.md
@@ -9,7 +9,7 @@ a [Map](https://developers.google.com/maps/documentation/javascript/reference/ma
 
 ```tsx
 import React, {FunctionComponent} from 'react';
-import {APIProvider, Map} from '@vis.gl/react-google-maps-components';
+import {APIProvider, Map} from '@vis.gl/react-google-maps';
 
 const App: FunctionComponent<Record<string, unknown>> = () => (
   <APIProvider apiKey={'Your API key here'}>
@@ -25,7 +25,7 @@ Apply an id to each `Map` component when using multiple `Map` components.
 
 ```tsx
 import React, {FunctionComponent} from 'react';
-import {APIProvider, Map} from '@vis.gl/react-google-maps-components';
+import {APIProvider, Map} from '@vis.gl/react-google-maps';
 
 const App: FunctionComponent<Record<string, unknown>> = () => (
   <APIProvider apiKey={'Your API key here'}>

--- a/docs/api-reference/components/marker.md
+++ b/docs/api-reference/components/marker.md
@@ -6,7 +6,7 @@ React component to display a [Marker](https://developers.google.com/maps/documen
 
 ```tsx
 import React, {FunctionComponent} from 'react';
-import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps-components';
+import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps';
 
 const App: FunctionComponent<Record<string, unknown>> = () => (
   <APIProvider apiKey={'Your API key here'}>


### PR DESCRIPTION
- use the correct package name in the examples