### PR TITLE
feat: add onClick event for map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist
 /examples/**/package-lock.json
 /examples/**/node_modules
+/examples/**/.env

--- a/docs/api-reference/components/map.md
+++ b/docs/api-reference/components/map.md
@@ -127,6 +127,7 @@ interface MapProps extends google.maps.MapOptions {
   id?: string;
   style?: CSSProperties;
   className?: string;
+  onClick?: (event: google.maps.Map) => void;
   initialBounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
   onLoadMap?: (map: google.maps.Map) => void;
   viewport?: unknown;

--- a/examples/map-on-click/README.md
+++ b/examples/map-on-click/README.md
@@ -1,0 +1,32 @@
+# Google Maps with onClick event Example
+
+![image](https://user-images.githubusercontent.com/2131246/280457336-82123c40-4779-4345-99c3-727d4f817b96.png)
+
+This is an example to show how to setup an onClick event on Google Maps Map with the `<Map/>` component of the Google Maps React
+library.
+
+## Instructions
+
+Go into the example-directory and run
+
+```shell
+npm install
+```
+
+Then start the example with
+
+```shell
+npm start
+```
+
+Running the examples locally requires a valid API key for the Google Maps Platform.
+See [the official documentation][get-api-key] on how to create and configure your own key.
+
+The API key has to be provided via an environment variable `GOOGLE_MAPS_API_KEY`. This can be done by creating a
+file named `.env` in the example directory with the following content:
+
+```shell title=".env"
+GOOGLE_MAPS_API_KEY="<YOUR API KEY HERE>"
+```
+
+[get-api-key]: https://developers.google.com/maps/documentation/javascript/get-api-key

--- a/examples/map-on-click/index.html
+++ b/examples/map-on-click/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <title>Google Maps Map Component with onClick event Example</title>
+    <meta name="description" content="Google Maps Map Component Example" />
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+
+      #app {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="app" style=""></div>
+    <script type="module">
+      import '../../website/src/styles.css';
+      import {renderToDom} from './src/app';
+      renderToDom(document.querySelector('#app'));
+    </script>
+  </body>
+</html>

--- a/examples/map-on-click/package.json
+++ b/examples/map-on-click/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "@vis.gl/react-google-maps": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "vite": "^4.3.9"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  }
+}

--- a/examples/map-on-click/src/app.tsx
+++ b/examples/map-on-click/src/app.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+
+import {APIProvider, Map} from '@vis.gl/react-google-maps';
+import ControlPanel from './control-panel';
+
+const API_KEY = process.env.GOOGLE_MAPS_API_KEY as string;
+
+const App = () => (
+  <APIProvider apiKey={API_KEY}>
+    <Map
+      onClick={console.log}
+      zoom={3}
+      center={{lat: 22.54992, lng: 0}}
+      gestureHandling={'greedy'}
+      disableDefaultUI={true}
+    />
+    <ControlPanel />
+  </APIProvider>
+);
+export default App;
+
+export function renderToDom(container: HTMLElement) {
+  const root = createRoot(container);
+
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/examples/map-on-click/src/control-panel.tsx
+++ b/examples/map-on-click/src/control-panel.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+function ControlPanel() {
+  return (
+    <div className="control-panel">
+      <h3>Basic Map with onClick event</h3>
+      <p>
+        The basic example of Google Maps with onCLick event that returns the
+        current map in the callback.
+      </p>
+      <div className="source-link">
+        <a
+          href="https://github.com/visgl/react-google-maps/tree/main/examples/map-on-click"
+          target="_new">
+          View Code ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(ControlPanel);

--- a/examples/map-on-click/vite.config.js
+++ b/examples/map-on-click/vite.config.js
@@ -1,0 +1,17 @@
+import {defineConfig, loadEnv} from 'vite';
+import {resolve} from 'node:path';
+
+export default defineConfig(({mode}) => {
+  const {GOOGLE_MAPS_API_KEY} = loadEnv(mode, process.cwd(), '');
+
+  return {
+    define: {
+      'process.env.GOOGLE_MAPS_API_KEY': JSON.stringify(GOOGLE_MAPS_API_KEY)
+    },
+    resolve: {
+      alias: {
+        '@vis.gl/react-google-maps': resolve('../../src/index.ts')
+      }
+    }
+  };
+});

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import React, {
   CSSProperties,
-  PropsWithChildren,
+  ComponentPropsWithRef,
   useCallback,
   useContext,
   useEffect,
@@ -58,12 +58,16 @@ export type MapProps = google.maps.MapOptions & {
    * Initial View State from deck.gl
    */
   initialViewState?: Record<string, unknown>;
+  /**
+   * Callback function that is called when the map is clicked
+   */
+  onClick?: (event: google.maps.Map) => void;
 };
 
 /**
  * Component to render a Google Maps map
  */
-export const Map = (props: PropsWithChildren<MapProps>) => {
+export const Map = (props: MapProps & ComponentPropsWithRef<'div'>) => {
   const {children, id, className, style, viewState, viewport} = props;
 
   const context = useContext(APIProviderContext) as APIProviderContextValue;
@@ -128,6 +132,7 @@ function useMapInstanceHandlerEffects(
   const {
     id,
     initialBounds,
+    onClick,
     onLoadMap,
     // FIXME: this destructuring here leads to mapOptions being a new
     //   object for every render, and we'll be calling map.setOptions() a lot.
@@ -157,6 +162,14 @@ function useMapInstanceHandlerEffects(
       if (onLoadMap) {
         google.maps.event.addListenerOnce(newMap, 'idle', () => {
           onLoadMap(newMap);
+        });
+      }
+
+      if (onClick) {
+        google.maps.event.addListenerOnce(newMap, 'idle', () => {
+          google.maps.event.addListener(newMap, 'click', () => {
+            onClick(newMap);
+          });
         });
       }
 


### PR DESCRIPTION
Hi,

This PR adds `onClick` event support for the map. This addresses the #49.

As part of this PR I have:
- [x] add an example
- [x] updated API reference
- [ ] wrote unit test coverage

**Unit tests**
I have tried to put a basic unit test but it just won't work so I would appreciate the help/feedback with this. Here is the example I tried with:

``` js
test('onClick handler is called when map is clicked', () => {
  createMapSpy.mockReset();
  const onClick = jest.fn();
  rerender(
    <GoogleMap id={'mymap'} center={center} zoom={14} onClick={onClick} />
  );

  screen.getByTestId('map').click();
  expect(onClick).toHaveBeenCalledTimes(1);
});
```