### PR TITLE
fix: move @types/google.maps to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "@vis.gl/react-google-maps",
       "version": "0.4.0",
       "license": "MIT",
+      "dependencies": {
+        "@types/google.maps": "^3.54.10"
+      },
       "devDependencies": {
         "@googlemaps/jest-mocks": "^2.18.0",
         "@testing-library/jest-dom": "^6.0.1",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
-        "@types/google.maps": "^3.50.5",
         "@types/jest": "^29.4.0",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
@@ -3544,10 +3546,9 @@
       "dev": true
     },
     "node_modules/@types/google.maps": {
-      "version": "3.54.9",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.54.9.tgz",
-      "integrity": "sha512-kovzglL9eC/zsMnhIpBsiuUDPwhNsRDQzjtKDHZ3D4lYHi7l7IgZPE8/yz+I4Wb96cQXkz2W0DcOiF5RaNPovA==",
-      "dev": true
+      "version": "3.54.10",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.54.10.tgz",
+      "integrity": "sha512-N6gwM01mKhooXaw+IKbUH7wJcIJCn8U60VoaVvom5EiQjmfgevhQ+0+/r17beXW5j8ad2x+WPr0iyOUodCw4/w=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "Google Maps",
     "Google Maps components"
   ],
+  "dependencies": {
+    "@types/google.maps": "^3.54.10"
+  },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
@@ -58,7 +61,6 @@
     "@testing-library/jest-dom": "^6.0.1",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/google.maps": "^3.50.5",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",


### PR DESCRIPTION
we are reusing types from the @types/google.maps package for things like MapProps etc. To make sure those types are available when installing this package, we have to specify them as dependencies instead of devDependencies.

fixes #106
