### PR TITLE
docs: make control panel and info window text readable in dark mode

### DIFF
--- a/examples/examples.css
+++ b/examples/examples.css
@@ -36,10 +36,10 @@
   font-size: 11px;
 }
 
-html[data-theme="dark"] .control-panel {
+html[data-theme='dark'] .control-panel {
   background: var(--ifm-background-color);
 }
 
-html[data-theme="dark"] .gm-style {
+html[data-theme='dark'] .gm-style {
   color: var(--ifm-color-black);
 }

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -35,3 +35,11 @@
   color: #486865;
   font-size: 11px;
 }
+
+html[data-theme="dark"] .control-panel {
+  background: var(--ifm-background-color);
+}
+
+html[data-theme="dark"] .gm-style {
+  color: var(--ifm-color-black);
+}


### PR DESCRIPTION
Before:
<img width="1263" alt="Screenshot 2023-12-07 at 8 05 43 AM" src="https://github.com/visgl/react-google-maps/assets/12741379/5838f0e9-452c-44fb-ba4e-15004bd94a71">

After:
<img width="1256" alt="Screenshot 2023-12-07 at 8 02 41 AM" src="https://github.com/visgl/react-google-maps/assets/12741379/41cd7f86-f8d3-4288-add6-e4e9a4ea14cf">
