### PR TITLE
docs: fix link label errors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,8 @@ to as having a _single source of truth_. That could be stored in a parent
 component state, a Redux store, or react-hooks, and let it propagate down
 to the map and any other component.
 
-Ultimately, in the spirit of the [reactive programming paradigm]
-[wiki-reactive] used in React, data from this single source of truth should
+Ultimately, in the spirit of the [reactive programming paradigm][wiki-reactive]
+used in React, data from this single source of truth should
 always flow down the component hierarchy. If components manage their own
 state, as Google Maps is designed to do, we risk the components going out of
 sync.
@@ -54,9 +54,9 @@ initial values, and users will be able to interact with the map without
 requiring the props to be updated. So by default, the map is allowed to
 deviate from the specified values.
 
-However, the [Map][docs-map] component can also be used as a fully [controlled]
-[react-controlled] component. That is, the map's camera will never deviate
-from the props that have been assigned. In this mode, the controls
+However, the [Map][docs-map] component can also be used as a fully
+[controlled][react-controlled] component. That is, the map's camera will never
+deviate from the props that have been assigned. In this mode, the controls
 provided by the map can still be used by listening for the appropriate
 events and updating the state accordingly.
 


### PR DESCRIPTION
Hi, I found that the "introduction" page (https://visgl.github.io/react-google-maps/docs generated from `docs/README.md`) had two broken links.

![Screenshot from 2023-12-13 01-23-41](https://github.com/visgl/react-google-maps/assets/1425259/850c7007-27b1-4680-87f3-8051efec866d)

These were caused by an extra newline between anchor text and alias links in Markdown, probably due to the autoformatting. This PR fixes it by adjusting newline positions while keeping up to 80 characters/line. 