### PR TITLE
fix: avoid re-render on every importLibrary() call

### DIFF
--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -142,7 +142,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 
       return res;
     },
-    []
+    [loadedLibraries]
   );
 
   useEffect(


### PR DESCRIPTION
`importLibrary()` depends on `loadedLibraries` but that is not stated in the deps array. This cause check: 

```js
if (loadedLibraries[name]) {
  return loadedLibraries[name];
}
```

Not working, because `loadedLibraries` always empty and therefore every `importLibrary()` call even for libraries which are already loaded cause full re-render of all components depending on map context. 
