### PR TITLE
fix: allow AdvancedMarker to accept space-separated multiple class names

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -79,7 +79,7 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
     // create container for marker content if there are children
     if (numChilds > 0) {
       const el = document.createElement('div');
-      if (className) el.classList.add(className);
+      if (className) el.className = className;
 
       newMarker.content = el;
 


### PR DESCRIPTION
fix #142

If we want to use `classList.add` to add multiple class names while keeping the existing class names, we could write like this:

```ts
const classNames = className.split(' ')
el.classList.add(...classNames);
```

But we simply add class names to a brand new `div` element here so I think we can add the provided `className` as is.