### PR TITLE
feat: handle API-key errors in map-component

### DIFF
--- a/src/components/__tests__/map.test.tsx
+++ b/src/components/__tests__/map.test.tsx
@@ -4,11 +4,8 @@ import {initialize, mockInstances} from '@googlemaps/jest-mocks';
 import '@testing-library/jest-dom';
 
 import {Map as GoogleMap} from '../map';
-import {
-  APILoadingStatus,
-  APIProviderContext,
-  APIProviderContextValue
-} from '../api-provider';
+import {APIProviderContext, APIProviderContextValue} from '../api-provider';
+import {APILoadingStatus} from '../../libraries/api-loading-status';
 
 jest.mock('../../libraries/google-maps-api-loader');
 

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -18,6 +18,8 @@ import {MapEventProps, useMapEvents} from './use-map-events';
 import {useMapOptions} from './use-map-options';
 import {useDeckGLCameraUpdate} from './use-deckgl-camera-update';
 import {useInternalCameraState} from './use-internal-camera-state';
+import {useApiLoadingStatus} from '../../hooks/use-api-loading-status';
+import {APILoadingStatus} from '../../libraries/api-loading-status';
 
 export interface GoogleMapsContextValue {
   map: google.maps.Map | null;
@@ -66,6 +68,7 @@ export const Map = (props: PropsWithChildren<MapProps>) => {
   const {children, id, className, style, viewState, viewport} = props;
 
   const context = useContext(APIProviderContext);
+  const loadingStatus = useApiLoadingStatus();
 
   if (!context) {
     throw new Error(
@@ -92,6 +95,16 @@ export const Map = (props: PropsWithChildren<MapProps>) => {
     [style, isViewportSet]
   );
 
+  if (loadingStatus === APILoadingStatus.AUTH_FAILURE) {
+    return (
+      <div
+        style={{position: 'relative', ...(className ? {} : combinedStyle)}}
+        className={className}>
+        <AuthFailureMessage />
+      </div>
+    );
+  }
+
   return (
     <div
       ref={mapRef}
@@ -108,6 +121,36 @@ export const Map = (props: PropsWithChildren<MapProps>) => {
   );
 };
 Map.deckGLViewProps = true;
+
+const AuthFailureMessage = () => {
+  const style: CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    zIndex: 999,
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    textAlign: 'center',
+    justifyContent: 'center',
+    fontSize: '.8rem',
+    color: 'rgba(0,0,0,0.6)',
+    background: '#dddddd',
+    padding: '1rem 1.5rem'
+  };
+
+  return (
+    <div style={style}>
+      <h2>Error: AuthFailure</h2>
+      <p>
+        A problem with your API key prevents the map from rendering correctly.
+        Please make sure the value of the <code>APIProvider.apiKey</code> prop
+        is correct. Check the error-message in the console for further details.
+      </p>
+    </div>
+  );
+};
 
 /**
  * The main hook takes care of creating map-instances and registering them in

--- a/src/hooks/__tests__/api-loading.test.tsx
+++ b/src/hooks/__tests__/api-loading.test.tsx
@@ -3,13 +3,13 @@ import {initialize} from '@googlemaps/jest-mocks';
 import {renderHook} from '@testing-library/react';
 
 import {
-  APILoadingStatus,
   APIProviderContext,
   APIProviderContextValue
 } from '../../components/api-provider';
 
 import {useApiLoadingStatus} from '../use-api-loading-status';
 import {useApiIsLoaded} from '../use-api-is-loaded';
+import {APILoadingStatus} from '../../libraries/api-loading-status';
 
 let wrapper: ({children}: {children: React.ReactNode}) => JSX.Element | null;
 let mockContextValue: jest.MockedObject<APIProviderContextValue>;

--- a/src/hooks/__tests__/use-map.test.tsx
+++ b/src/hooks/__tests__/use-map.test.tsx
@@ -5,11 +5,11 @@ import {initialize, mockInstances} from '@googlemaps/jest-mocks';
 
 import {useMap} from '../use-map';
 import {
-  APILoadingStatus,
   APIProviderContext,
   APIProviderContextValue
 } from '../../components/api-provider';
 import {Map as GoogleMap} from '../../components/map';
+import {APILoadingStatus} from '../../libraries/api-loading-status';
 
 let MockApiContextProvider: ({
   children

--- a/src/hooks/use-api-is-loaded.ts
+++ b/src/hooks/use-api-is-loaded.ts
@@ -1,5 +1,5 @@
-import {APILoadingStatus} from '../components/api-provider';
 import {useApiLoadingStatus} from './use-api-loading-status';
+import {APILoadingStatus} from '../libraries/api-loading-status';
 /**
  * Hook to check if the Google Maps API is loaded
  */

--- a/src/hooks/use-api-loading-status.ts
+++ b/src/hooks/use-api-loading-status.ts
@@ -1,5 +1,6 @@
 import {useContext} from 'react';
-import {APILoadingStatus, APIProviderContext} from '../components/api-provider';
+import {APIProviderContext} from '../components/api-provider';
+import {APILoadingStatus} from '../libraries/api-loading-status';
 
 export function useApiLoadingStatus(): APILoadingStatus {
   return useContext(APIProviderContext)?.status || APILoadingStatus.NOT_LOADED;

--- a/src/libraries/__mocks__/google-maps-api-loader.ts
+++ b/src/libraries/__mocks__/google-maps-api-loader.ts
@@ -2,10 +2,15 @@ import type {GoogleMapsApiLoader as ActualLoader} from '../google-maps-api-loade
 
 // FIXME: this should no longer be needed with the next version of @googlemaps/jest-mocks
 import {importLibraryMock} from './lib/import-library-mock';
+import {APILoadingStatus} from '../api-loading-status';
 
 export class GoogleMapsApiLoader {
-  static load: typeof ActualLoader.load = jest.fn(() => {
-    google.maps.importLibrary = importLibraryMock;
-    return Promise.resolve();
-  });
+  static loadingStatus: APILoadingStatus = APILoadingStatus.LOADED;
+  static load: typeof ActualLoader.load = jest.fn(
+    (_, onLoadingStatusChange) => {
+      google.maps.importLibrary = importLibraryMock;
+      onLoadingStatusChange(APILoadingStatus.LOADED);
+      return Promise.resolve();
+    }
+  );
 }

--- a/src/libraries/api-loading-status.ts
+++ b/src/libraries/api-loading-status.ts
@@ -1,0 +1,9 @@
+export const APILoadingStatus = {
+  NOT_LOADED: 'NOT_LOADED',
+  LOADING: 'LOADING',
+  LOADED: 'LOADED',
+  FAILED: 'FAILED',
+  AUTH_FAILURE: 'AUTH_FAILURE'
+};
+export type APILoadingStatus =
+  (typeof APILoadingStatus)[keyof typeof APILoadingStatus];


### PR DESCRIPTION
Introduces handling for API-key errors (via the gm_authFailed callback) for the map-component.

This also shifts responsibility for tracking the loading status into the GoogleMapsApiLoader class, to avoid problems when the APIProvider itself is rendered conditionally.