### PR TITLE
refactor(use-map-instance): remove unused import

### DIFF
--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -1,4 +1,4 @@
-import {Ref, useEffect, useRef, useState} from 'react';
+import {Ref, useEffect, useState} from 'react';
 
 import {MapProps} from '../map';
 import {APIProviderContextValue} from '../api-provider';


### PR DESCRIPTION
Hi, this is a simple fix to address one ESLint warning.

ref. https://github.com/visgl/react-google-maps/actions/runs/7817624474/job/21325966198#step:5:25