### PR TITLE
fix: remove deep-link into fast-deep-equal package

### DIFF
--- a/src/libraries/use-deep-compare-effect.tsx
+++ b/src/libraries/use-deep-compare-effect.tsx
@@ -1,5 +1,5 @@
 import {DependencyList, EffectCallback, useEffect, useRef} from 'react';
-import isDeepEqual from 'fast-deep-equal/react';
+import isDeepEqual from 'fast-deep-equal';
 
 export function useDeepCompareEffect(
   effect: EffectCallback,


### PR DESCRIPTION
In the compiled esm-package, the import of `fast-deep-equal/react` is producing errors (seems like it should have been transformed into `fast-deep-equal/react.js` at somoe point during build. But since I don't think we actually need the react-specific parts of fast-deep-equal, we can just leave that away for now and figure out how to do these deep imports correctly later.

fixes #207 