### PR TITLE
docs: fix a link error in `map.md`

### DIFF
--- a/docs/api-reference/components/map.md
+++ b/docs/api-reference/components/map.md
@@ -67,9 +67,8 @@ anything not specified in the camera props.
 
 ## Props
 
-The `MapProps` type extends the [`google.maps.MapOptions` interface]
-[gmp-map-options] and includes all possible options available for a Google
-Map as props.
+The `MapProps` type extends the [`google.maps.MapOptions` interface][gmp-map-options]
+and includes all possible options available for a Google Map as props.
 
 The most important of these options are also listed below along with the
 properties added for the react-library.
@@ -131,8 +130,7 @@ is approximately:
 - `15`: Streets
 - `20`: Buildings
 
-The Google Maps API Documentation [has some more information on this topic].
-[gmp-coordinates].
+The Google Maps API Documentation [has some more information on this topic][gmp-coordinates].
 
 #### `heading`: number
 


### PR DESCRIPTION
Just found two small link syntax errors 🙂 

This fixes the following two places:
- https://visgl.github.io/react-google-maps/docs/api-reference/components/map#props:~:text=The%20MapProps%20type%20extends%20the
- https://visgl.github.io/react-google-maps/docs/api-reference/components/map#props:~:text=The%20Google%20Maps%20API%20Documentation
