### PR TITLE
Update info-window.md

### DIFF
--- a/docs/api-reference/components/info-window.md
+++ b/docs/api-reference/components/info-window.md
@@ -90,7 +90,7 @@ const App = () => {
 
   return (
     <APIProvider apiKey={'Your API key here'}>
-      <Map zoom={12} center={{lat: 53.54992, lng: 10.00678}}>
+      <Map zoom={12} center={{lat: 53.54992, lng: 10.00678}} mapId={'<Your custom MapId here>'}>
         <AdvancedMarker
           ref={markerRef}
           position={{lat: 53.54992, lng: 10.00678}}


### PR DESCRIPTION
Using <AdvancedMarker> requires that the Map has a MapId. This was actually mentioned in the documentation of your <AdvancedMarker. However, in the <InfoWindow> component example when using AdvancedMarker, MapId props was not specified. 

Hence, I added the mapId prop so users will know to add their MapId when using the example provided on InfoWindow.