### PR TITLE
fix a bug where false would not be detected as parameter false

### DIFF
--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -98,7 +98,7 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
       openOptions.anchor = anchor;
     }
 
-    if (shouldFocus === true || shouldFocus === false) {
+    if (shouldFocus !== undefined) {
       openOptions.shouldFocus = shouldFocus;
     }
 

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -16,7 +16,7 @@ import {GoogleMapsContext} from './map';
 export type InfoWindowProps = google.maps.InfoWindowOptions & {
   onCloseClick?: () => void;
   anchor?: google.maps.Marker | google.maps.marker.AdvancedMarkerElement | null;
-  shouldFocus?: boolean | null;
+  shouldFocus?: boolean;
 };
 
 /**

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -22,7 +22,7 @@ export type InfoWindowProps = google.maps.InfoWindowOptions & {
  * Component to render a Google Maps Info Window
  */
 export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
-  const {children, anchor, onCloseClick, ...infoWindowOptions} = props;
+  const {children, anchor, shouldFocus, onCloseClick, ...infoWindowOptions} = props;
   const map = useContext(GoogleMapsContext)?.map;
 
   const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
@@ -94,6 +94,10 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
 
     if (anchor) {
       openOptions.anchor = anchor;
+    }
+
+    if(shouldFocus) {
+      openOptions.shouldFocus = shouldFocus;
     }
 
     infoWindowRef.current.open(openOptions);

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -103,7 +103,7 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
     }
 
     infoWindowRef.current.open(openOptions);
-  }, [contentContainer, infoWindowRef, anchor, map]);
+  }, [contentContainer, infoWindowRef, anchor, map, shouldFocus]);
 
   return (
     <>{contentContainer !== null && createPortal(children, contentContainer)}</>

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -98,7 +98,7 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
       openOptions.anchor = anchor;
     }
 
-    if (shouldFocus) {
+    if (shouldFocus === true || shouldFocus === false) {
       openOptions.shouldFocus = shouldFocus;
     }
 

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -16,6 +16,7 @@ import {GoogleMapsContext} from './map';
 export type InfoWindowProps = google.maps.InfoWindowOptions & {
   onCloseClick?: () => void;
   anchor?: google.maps.Marker | google.maps.marker.AdvancedMarkerElement | null;
+  shouldFocus?: boolean | null;
 };
 
 /**

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -23,7 +23,8 @@ export type InfoWindowProps = google.maps.InfoWindowOptions & {
  * Component to render a Google Maps Info Window
  */
 export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
-  const {children, anchor, shouldFocus, onCloseClick, ...infoWindowOptions} = props;
+  const {children, anchor, shouldFocus, onCloseClick, ...infoWindowOptions} =
+    props;
   const map = useContext(GoogleMapsContext)?.map;
 
   const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
@@ -97,7 +98,7 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
       openOptions.anchor = anchor;
     }
 
-    if(shouldFocus) {
+    if (shouldFocus) {
       openOptions.shouldFocus = shouldFocus;
     }
 


### PR DESCRIPTION
realized that if shouldFocus is set to false, then it will not be set at all in the open call, so added distinguisher from null, sorry for the oversight!