### PR TITLE
Export ApiLibraryKeys for use in client code

### DIFF
--- a/src/hooks/use-maps-library.ts
+++ b/src/hooks/use-maps-library.ts
@@ -18,8 +18,10 @@ interface ApiLibraries {
   visualization: google.maps.VisualizationLibrary;
 }
 
+export type ApiLibraryKeys = keyof ApiLibraries;
+
 export function useMapsLibrary<
-  K extends keyof ApiLibraries,
+  K extends ApiLibraryKeys,
   V extends ApiLibraries[K]
 >(name: K): V | null;
 


### PR DESCRIPTION
This way clients won't have to make their own copy ApiLibrary keys. Not sure if there's a better name than `ApiLibraryKeys`.


**Alternatively** a client could extract the type with something like:
```
type FirstArg<F extends (...args: never) => unknown> = Parameters<F>[0];
type ApiLibrary = FirstArg<typeof useMapsLibrary>;
```
But I'd consider that a _hack_. Better to just export the type imho. 🙏