### PR TITLE
Fix map controls crashing when invalid key is provided

### DIFF
--- a/src/components/map-control.tsx
+++ b/src/components/map-control.tsx
@@ -58,7 +58,7 @@ export const MapControl = ({children, position}: MapControlProps) => {
     controls.push(controlContainer);
 
     return () => {
-      const index = controls.getArray().indexOf(controlContainer);
+      const index = controls.getArray()?.indexOf(controlContainer);
       controls.removeAt(index);
     };
   }, [controlContainer, map, position]);


### PR DESCRIPTION
I'm having the same issue reported on #276.

I tested it and adding optional chaining before calling indexOf fixes it.

closes #276