### PR TITLE
feat: dissalow map prop for markers

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -31,7 +31,10 @@ type AdvancedMarkerEventProps = {
 };
 
 export type AdvancedMarkerProps = PropsWithChildren<
-  Omit<google.maps.marker.AdvancedMarkerElementOptions, 'gmpDraggable'> &
+  Omit<
+    google.maps.marker.AdvancedMarkerElementOptions,
+    'gmpDraggable' | 'map'
+  > &
     AdvancedMarkerEventProps & {
       /**
        * className to add a class to the advanced marker element

--- a/src/components/marker.tsx
+++ b/src/components/marker.tsx
@@ -21,7 +21,8 @@ type MarkerEventProps = {
   onMouseOut?: (e: google.maps.MapMouseEvent) => void;
 };
 
-export type MarkerProps = Omit<google.maps.MarkerOptions, "map"> & MarkerEventProps;
+export type MarkerProps = Omit<google.maps.MarkerOptions, 'map'> &
+  MarkerEventProps;
 
 export type MarkerRef = Ref<google.maps.Marker | null>;
 

--- a/src/components/marker.tsx
+++ b/src/components/marker.tsx
@@ -21,7 +21,7 @@ type MarkerEventProps = {
   onMouseOut?: (e: google.maps.MapMouseEvent) => void;
 };
 
-export type MarkerProps = google.maps.MarkerOptions & MarkerEventProps;
+export type MarkerProps = Omit<google.maps.MarkerOptions, "map"> & MarkerEventProps;
 
 export type MarkerRef = Ref<google.maps.Marker | null>;
 


### PR DESCRIPTION
Closes #284 

- [x] check in ts examples that vs code doesn't suggest map prop
  - [x] marker
  - [x] advanced-marker
  - [x] info-window (didn't had map prop)
  - [x] map-control (didn't had map prop)
