### PR TITLE
refactor: use useMap in couple of places

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -11,9 +11,9 @@ import React, {
 
 import {createPortal} from 'react-dom';
 import {useMap} from '../hooks/use-map';
+import {useMapsLibrary} from '../hooks/use-maps-library';
 
 import type {Ref, PropsWithChildren} from 'react';
-import {useMapsLibrary} from '../hooks/use-maps-library';
 
 export interface AdvancedMarkerContextValue {
   marker: google.maps.marker.AdvancedMarkerElement;

--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -3,7 +3,6 @@ import React, {
   Children,
   forwardRef,
   useCallback,
-  useContext,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -11,7 +10,7 @@ import React, {
 } from 'react';
 
 import {createPortal} from 'react-dom';
-import {GoogleMapsContext} from './map';
+import {useMap} from '../hooks/use-map';
 
 import type {Ref, PropsWithChildren} from 'react';
 import {useMapsLibrary} from '../hooks/use-maps-library';
@@ -49,7 +48,7 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
   const [contentContainer, setContentContainer] =
     useState<HTMLDivElement | null>(null);
 
-  const map = useContext(GoogleMapsContext)?.map;
+  const map = useMap();
   const markerLibrary = useMapsLibrary('marker');
 
   const {

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -1,10 +1,5 @@
 /* eslint-disable complexity */
-import React, {
-  PropsWithChildren,
-  useEffect,
-  useRef,
-  useState
-} from 'react';
+import React, {PropsWithChildren, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 import {useMap} from '../hooks/use-map';

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable complexity */
 import React, {
   PropsWithChildren,
-  useContext,
   useEffect,
   useRef,
   useState
 } from 'react';
 import {createPortal} from 'react-dom';
 
-import {GoogleMapsContext} from './map';
+import {useMap} from '../hooks/use-map';
 
 /**
  * Props for the Info Window Component
@@ -25,7 +24,7 @@ export type InfoWindowProps = google.maps.InfoWindowOptions & {
 export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
   const {children, anchor, shouldFocus, onCloseClick, ...infoWindowOptions} =
     props;
-  const map = useContext(GoogleMapsContext)?.map;
+  const map = useMap();
 
   const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
   const [contentContainer, setContentContainer] =

--- a/src/components/marker.tsx
+++ b/src/components/marker.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 
 import {GoogleMapsContext} from './map';
+import {useMap} from '../hooks/use-map';
 
 import type {Ref} from 'react';
 
@@ -27,7 +28,7 @@ export type MarkerRef = Ref<google.maps.Marker | null>;
 
 function useMarker(props: MarkerProps) {
   const [marker, setMarker] = useState<google.maps.Marker | null>(null);
-  const map = useContext(GoogleMapsContext)?.map;
+  const map = useMap();
 
   const {
     onClick,

--- a/src/components/marker.tsx
+++ b/src/components/marker.tsx
@@ -2,13 +2,11 @@
 import React, {
   forwardRef,
   useCallback,
-  useContext,
   useEffect,
   useImperativeHandle,
   useState
 } from 'react';
 
-import {GoogleMapsContext} from './map';
 import {useMap} from '../hooks/use-map';
 
 import type {Ref} from 'react';


### PR DESCRIPTION
Just few swaps of `useContext` into convienient `useMap`.

swap in:
- [x] marker
- [x] info-window
- [x] advanced-marker
- [x] source search for other places