### PR TITLE
feat: useApi hook

### DIFF
--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -6,14 +6,11 @@ import '@testing-library/jest-dom';
 // FIXME: this should no longer be needed with the next version of @googlemaps/jest-mocks
 import {importLibraryMock} from '../../libraries/__mocks__/lib/import-library-mock';
 
-import {
-  APIProvider,
-  APIProviderContextValue
-} from '../api-provider';
+import {APIProvider, APIProviderContextValue} from '../api-provider';
 import {ApiParams} from '../../libraries/google-maps-api-loader';
 import {useApiIsLoaded} from '../../hooks/use-api-is-loaded';
 import {APILoadingStatus} from '../../libraries/api-loading-status';
-import { useApi } from '../../hooks/use-api';
+import {useApi} from '../../hooks/use-api';
 
 const apiLoadSpy = jest.fn();
 const apiUnloadSpy = jest.fn();

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -2,13 +2,10 @@
 import React, {
   CSSProperties,
   PropsWithChildren,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo
 } from 'react';
-
-import {APIProviderContext} from '../api-provider';
 
 import {MapEventProps, useMapEvents} from './use-map-events';
 import {useMapOptions} from './use-map-options';
@@ -22,6 +19,7 @@ import {toLatLngLiteral} from '../../libraries/lat-lng-utils';
 import {useMapCameraParams} from './use-map-camera-params';
 import {AuthFailureMessage} from './auth-failure-message';
 import {useMapInstance} from './use-map-instance';
+import {useApi} from '../../hooks/use-api';
 
 export interface GoogleMapsContextValue {
   map: google.maps.Map | null;
@@ -79,16 +77,16 @@ export type MapProps = google.maps.MapOptions &
 
 export const Map = (props: PropsWithChildren<MapProps>) => {
   const {children, id, className, style} = props;
-  const context = useContext(APIProviderContext);
+  const api = useApi();
   const loadingStatus = useApiLoadingStatus();
 
-  if (!context) {
+  if (!api) {
     throw new Error(
       '<Map> can only be used inside an <ApiProvider> component.'
     );
   }
 
-  const [map, mapRef, cameraStateRef] = useMapInstance(props, context);
+  const [map, mapRef, cameraStateRef] = useMapInstance(props, api);
 
   useMapCameraParams(map, cameraStateRef, props);
   useMapEvents(map, props);

--- a/src/hooks/use-api-loading-status.ts
+++ b/src/hooks/use-api-loading-status.ts
@@ -1,7 +1,6 @@
-import {useContext} from 'react';
-import {APIProviderContext} from '../components/api-provider';
+import {useApi} from './use-api';
 import {APILoadingStatus} from '../libraries/api-loading-status';
 
 export function useApiLoadingStatus(): APILoadingStatus {
-  return useContext(APIProviderContext)?.status || APILoadingStatus.NOT_LOADED;
+  return useApi()?.status || APILoadingStatus.NOT_LOADED;
 }

--- a/src/hooks/use-api.ts
+++ b/src/hooks/use-api.ts
@@ -1,0 +1,10 @@
+import {useContext} from 'react';
+
+import {
+  APIProviderContext,
+  APIProviderContextValue
+} from '../components/api-provider';
+
+export const useApi = (): APIProviderContextValue | null => {
+  return useContext(APIProviderContext);
+};

--- a/src/hooks/use-map.ts
+++ b/src/hooks/use-map.ts
@@ -1,8 +1,8 @@
 import {useContext} from 'react';
 
-import {APIProviderContext} from '../components/api-provider';
 import {GoogleMapsContext} from '../components/map';
 import {logErrorOnce} from '../libraries/errors';
+import {useApi} from './use-api';
 
 /**
  * Retrieves a map-instance from the context. This is either an instance
@@ -10,10 +10,10 @@ import {logErrorOnce} from '../libraries/errors';
  * Returns null if neither can be found.
  */
 export const useMap = (id: string | null = null): google.maps.Map | null => {
-  const ctx = useContext(APIProviderContext);
+  const api = useApi();
   const {map} = useContext(GoogleMapsContext) || {};
 
-  if (ctx === null) {
+  if (api === null) {
     logErrorOnce(
       'useMap(): failed to retrieve APIProviderContext. ' +
         'Make sure that the <APIProvider> component exists and that the ' +
@@ -24,7 +24,7 @@ export const useMap = (id: string | null = null): google.maps.Map | null => {
     return null;
   }
 
-  const {mapInstances} = ctx;
+  const {mapInstances} = api;
 
   // if an id is specified, the corresponding map or null is returned
   if (id !== null) return mapInstances[id] || null;

--- a/src/hooks/use-maps-library.ts
+++ b/src/hooks/use-maps-library.ts
@@ -1,7 +1,7 @@
-import {useContext, useEffect} from 'react';
+import {useEffect} from 'react';
 
-import {APIProviderContext} from '../components/api-provider';
 import {useApiIsLoaded} from './use-api-is-loaded';
+import {useApi} from './use-api';
 
 interface ApiLibraries {
   core: google.maps.CoreLibrary;
@@ -25,16 +25,16 @@ export function useMapsLibrary<
 
 export function useMapsLibrary(name: string) {
   const apiIsLoaded = useApiIsLoaded();
-  const ctx = useContext(APIProviderContext);
+  const api = useApi();
 
   useEffect(() => {
-    if (!apiIsLoaded || !ctx) return;
+    if (!apiIsLoaded || !api) return;
 
     // Trigger loading the libraries via our proxy-method.
     // The returned promise is ignored, since importLibrary will update loadedLibraries
     // list in the context, triggering a re-render.
-    void ctx.importLibrary(name);
-  }, [apiIsLoaded, ctx, name]);
+    void api.importLibrary(name);
+  }, [apiIsLoaded, api, name]);
 
-  return ctx?.loadedLibraries[name] || null;
+  return api?.loadedLibraries[name] || null;
 }


### PR DESCRIPTION
While getting familiar with source, I was curious what's behind `ctx`/`context` in couple of places and would it be more clear to call it `api`? (or perhaps `mapsApi`). 

- [x] create useApi hook for convenience
- [x] apply
  - [x] in map/index 
  - [x] api-provider test
  - [x] use-maps-library hook
  - [x] use-map hook
  - [x] use-api-loading-status hook
- [ ] unit test of new hook 