### PR TITLE
feat: add support for solution-channel parameter

### DIFF
--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -103,6 +103,19 @@ when authorizing requests from the Maps JavaScript API.
 A list of [libraries][gmp-libs] to load immediately
 (libraries can also be loaded later with the `useMapsLibrary` hook).
 
+#### `solutionChannel`: string
+
+To help Google to better understand types of usage of the Google Maps 
+JavaScript API, the query parameter `solution_channel` can be set when 
+loading the API. 
+
+The `@vis.gl/react-google-maps` library will by default set 
+this to a generic value unique to this library (`GMP_VISGL_react`). You may 
+opt out at any time by setting this prop to an empty string.
+Read more in the [documentation][gmp-solutions-usage].
+
+### Events
+
 #### `onLoad`: () => void {#onLoad}
 
 a callback that is called once the Maps JavaScript
@@ -142,5 +155,6 @@ The following hooks are built to work with the `APIProvider` Component:
 [gmp-libs]: https://developers.google.com/maps/documentation/javascript/libraries
 [gmp-region]: https://developers.google.com/maps/documentation/javascript/localization#Region
 [gmp-lang]: https://developers.google.com/maps/documentation/javascript/localization
+[gmp-solutions-usage]: https://developers.google.com/maps/reporting-and-monitoring/reporting#solutions-usage
 [api-provider-src]: https://github.com/visgl/react-google-maps/blob/main/src/components/api-provider.tsx
 [rgm-new-issue]: https://github.com/visgl/react-google-maps/issues/new/choose

--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -96,6 +96,13 @@ test('uses default solutionChannel', () => {
   expect(actual.solutionChannel).toBe('GMP_VISGL_react');
 });
 
+test("doesn't set solutionChannel when specified as empty string", () => {
+  render(<APIProvider apiKey={'apikey'} solutionChannel={''}></APIProvider>);
+
+  const actual = apiLoadSpy.mock.lastCall[0];
+  expect(actual).not.toHaveProperty('solutionChannel');
+});
+
 test('renders inner components', async () => {
   const LoadingStatus = () => {
     const mapsLoaded = useApiIsLoaded();

--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -67,6 +67,7 @@ test('passes parameters to GoogleMapsAPILoader', () => {
       version={'beta'}
       language={'en'}
       region={'us'}
+      solutionChannel={'test-channel_value'}
       authReferrerPolicy={'origin'}></APIProvider>
   );
 
@@ -76,6 +77,7 @@ test('passes parameters to GoogleMapsAPILoader', () => {
     v: 'beta',
     language: 'en',
     region: 'us',
+    solutionChannel: 'test-channel_value',
     authReferrerPolicy: 'origin'
   });
 });

--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -83,10 +83,17 @@ test('passes parameters to GoogleMapsAPILoader', () => {
 });
 
 test('passes parameters to GoogleMapsAPILoader', () => {
+  render(<APIProvider apiKey={'apikey'} version={'version'}></APIProvider>);
+
+  const actual = apiLoadSpy.mock.lastCall[0];
+  expect(actual).toMatchObject({key: 'apikey', v: 'version'});
+});
+
+test('uses default solutionChannel', () => {
   render(<APIProvider apiKey={'apikey'}></APIProvider>);
 
   const actual = apiLoadSpy.mock.lastCall[0];
-  expect(Object.keys(actual)).toMatchObject(['key']);
+  expect(actual.solutionChannel).toBe('GMP_VISGL_react');
 });
 
 test('renders inner components', async () => {

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -66,6 +66,14 @@ export type APIProviderProps = {
    */
   authReferrerPolicy?: string;
   /**
+   * To understand usage and ways to improve our solutions, Google includes the
+   * `solution_channel` query parameter in API calls to gather information about
+   * code usage. You may opt out at any time by setting this attribute to an
+   * empty string. Read more in the
+   * [documentation](https://developers.google.com/maps/reporting-and-monitoring/reporting#solutions-usage).
+   */
+  solutionChannel?: string;
+  /**
    * A function that can be used to execute code after the Google Maps JavaScript API has been loaded.
    */
   onLoad?: () => void;
@@ -101,6 +109,7 @@ function useMapInstances() {
  */
 function useGoogleMapsApiLoader(props: APIProviderProps) {
   const {onLoad, apiKey, version, libraries = [], ...otherApiParams} = props;
+  const solutionChannel = props.solutionChannel || 'GMP_VISGL_react';
 
   const [status, setStatus] = useState<APILoadingStatus>(
     GoogleMapsApiLoader.loadingStatus
@@ -117,8 +126,8 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 
   const librariesString = useMemo(() => libraries?.join(','), [libraries]);
   const serializedParams = useMemo(
-    () => JSON.stringify({apiKey, version, ...otherApiParams}),
-    [apiKey, version, otherApiParams]
+    () => JSON.stringify({apiKey, version, solutionChannel, ...otherApiParams}),
+    [apiKey, version, solutionChannel, otherApiParams]
   );
 
   const importLibrary: typeof google.maps.importLibrary = useCallback(

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -159,8 +159,10 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
           const params: ApiParams = {key: apiKey, ...otherApiParams};
           if (version) params.v = version;
           if (librariesString?.length > 0) params.libraries = librariesString;
+
           if (params.solutionChannel === undefined)
             params.solutionChannel = DEFAULT_SOLUTION_CHANNEL;
+          else if (params.solutionChannel === '') delete params.solutionChannel;
 
           await GoogleMapsApiLoader.load(params, status => setStatus(status));
 

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -28,6 +28,8 @@ export interface APIProviderContextValue {
   clearMapInstances: () => void;
 }
 
+const DEFAULT_SOLUTION_CHANNEL = 'GMP_VISGL_react';
+
 export const APIProviderContext =
   React.createContext<APIProviderContextValue | null>(null);
 
@@ -109,7 +111,6 @@ function useMapInstances() {
  */
 function useGoogleMapsApiLoader(props: APIProviderProps) {
   const {onLoad, apiKey, version, libraries = [], ...otherApiParams} = props;
-  const solutionChannel = props.solutionChannel || 'GMP_VISGL_react';
 
   const [status, setStatus] = useState<APILoadingStatus>(
     GoogleMapsApiLoader.loadingStatus
@@ -126,8 +127,8 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 
   const librariesString = useMemo(() => libraries?.join(','), [libraries]);
   const serializedParams = useMemo(
-    () => JSON.stringify({apiKey, version, solutionChannel, ...otherApiParams}),
-    [apiKey, version, solutionChannel, otherApiParams]
+    () => JSON.stringify({apiKey, version, ...otherApiParams}),
+    [apiKey, version, otherApiParams]
   );
 
   const importLibrary: typeof google.maps.importLibrary = useCallback(
@@ -158,6 +159,8 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
           const params: ApiParams = {key: apiKey, ...otherApiParams};
           if (version) params.v = version;
           if (librariesString?.length > 0) params.libraries = librariesString;
+          if (params.solutionChannel === undefined)
+            params.solutionChannel = DEFAULT_SOLUTION_CHANNEL;
 
           await GoogleMapsApiLoader.load(params, status => setStatus(status));
 


### PR DESCRIPTION
The Maps JavaScript API loader supports a parameter `solutionChannel` ([documentation](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#optional_parameters)). This pull request adds support for the parameter, provides a default value if none is provided to override it, and adds a test to verify that it gets passed to the actual loading script.