### PR TITLE
docs(examples): add 'Polyline' geometry component (#105)

### DIFF
--- a/examples/geometry/README.md
+++ b/examples/geometry/README.md
@@ -130,3 +130,53 @@ interface PolygonProps extends google.maps.PolygonOptions {
 ```
 
 To see a Polygon on the Map, the `paths` or `encodedPaths` properties needs to be set.
+
+
+## `<Polyline>` Component
+
+React component to display a [Polyline](https://developers.google.com/maps/documentation/javascript/shapes#circles) instance.
+
+### Usage
+
+```tsx
+import React, {FunctionComponent} from 'react';
+import {APIProvider, Map} from '@vis.gl/react-google-maps';
+import {Polyline} from './components/polyline'; // import from your local file
+
+const App: FunctionComponent<Record<string, unknown>> = () => (
+  <APIProvider apiKey={'Your API key here'}>
+    <Map zoom={12} center={{lat: 53.54992, lng: 10.00678}}>
+      {/* Draw the Bermuda triangle */}
+      <Polyline
+        path={[
+          {lat: 25.774, lng: -80.19},
+          {lat: 18.466, lng: -66.118},
+          {lat: 32.321, lng: -64.757}
+        ]}
+      />
+
+      {/* Draw the Bermuda triangle with an encoded path */}
+      <Polyline encodedPath={'o~h|CnbmhN~irk@_m{tAw`qsAgyhG'} />
+    </Map>
+  </APIProvider>
+);
+export default App;
+```
+
+### Props
+
+The PolylineProps interface extends the [google.maps.PolylineOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polyline#Polyline) and includes all possible options available for a Google Maps Platform Polyline. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
+
+```tsx
+interface PolylineProps extends google.maps.PolylineOptions {
+  onClick?: (e: google.maps.MapMouseEvent) => void;
+  onDrag?: (e: google.maps.MapMouseEvent) => void;
+  onDragStart?: (e: google.maps.MapMouseEvent) => void;
+  onDragEnd?: (e: google.maps.MapMouseEvent) => void;
+  onMouseOver?: (e: google.maps.MapMouseEvent) => void;
+  onMouseOut?: (e: google.maps.MapMouseEvent) => void;
+  encodedPath?: string;
+}
+```
+
+To see a Polyline on the Map, the `path` or `encodedPath` properties needs to be set.

--- a/examples/geometry/src/app.tsx
+++ b/examples/geometry/src/app.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {APIProvider, Map, Marker} from '@vis.gl/react-google-maps';
-import {Circle, Polygon} from './components';
+import {Circle, Polygon, Polyline} from './components';
 import ControlPanel from './control-panel';
 
 import {POLYGONS} from './encoded-polygon-data';
+import {POLYLINE} from './encoded-polyline-data';
 
 const API_KEY =
   globalThis.GOOGLE_MAPS_API_KEY ?? (process.env.GOOGLE_MAPS_API_KEY as string);
@@ -36,6 +37,7 @@ const App = () => {
           }
         />
         <Polygon strokeWeight={1.5} encodedPaths={POLYGONS} />
+        <Polyline strokeWeight={1.5} encodedPath={POLYLINE} />
         <Circle
           radius={radius}
           center={center}

--- a/examples/geometry/src/components/index.ts
+++ b/examples/geometry/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './circle';
 export * from './polygon';
+export * from './polyline';

--- a/examples/geometry/src/encoded-polyline-data.ts
+++ b/examples/geometry/src/encoded-polyline-data.ts
@@ -1,0 +1,1 @@
+export const POLYLINE = 'mfo}FttclQux]_glApkOqa{@fjz@a{|A';


### PR DESCRIPTION
Addressing https://github.com/visgl/react-google-maps/issues/105

Added a new Polyline geometry component following the existing pattern with an example within the geometry app. Updated the Geometry readme.md to include the example. Basically the same as Polygon but with `encodedPath: string` instead of  `encodedPaths: string[]`