### PR TITLE
chore(eslint): add useDeepCompareEffect to exhaustive deps rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,8 +54,8 @@ module.exports = {
         'no-undef': 'off',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': [
-          "error", 
-          { "additionalHooks": "(useDeepCompareEffect)" }
+          'error',
+          {additionalHooks: '(useDeepCompareEffect)'}
         ],
         'react/jsx-no-constructed-context-values': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,10 @@ module.exports = {
 
         'no-undef': 'off',
         'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'warn',
+        "react-hooks/exhaustive-deps": [
+          "error", 
+          { "additionalHooks": "(useDeepCompareEffect)" }
+        ],
 
         // We use function hoisting to put exports at top of file
         '@typescript-eslint/no-use-before-define': 'off',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.configPath": ".prettierrc",
+  "javascript.validate.enable": false,
+  "editor.formatOnSave": true,
+  "editor.linkedEditing": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "prettier.configPath": ".prettierrc",
-  "javascript.validate.enable": false,
-  "editor.formatOnSave": true,
-  "editor.linkedEditing": true
-}


### PR DESCRIPTION
eslint should now report missing dependencies when using `useDeepCompareEffect`.