### PR TITLE
feat(map): implement initial version of map-instance caching

### DIFF
--- a/docs/api-reference/components/map.md
+++ b/docs/api-reference/components/map.md
@@ -18,10 +18,17 @@ const App = () => (
 );
 ```
 
-By default, the map will be added to the DOM with `width: 100%; height: 100%;`,
-assuming that the parent element will establish a size for the map. If that
-doesn't work in your case, you can adjust the styling of the map container
-using the [`style`](#style-reactcssproperties) and [`className`](#classname-string) props.
+:::note
+
+By default, the intrinsic height of a Google map is 0.
+To prevent this from causing confusion, the Map component uses a
+default-style of `width: 100%; height: 100%;` for the div-element containing
+the map, assuming that the parent element will establish a size for the map.
+If that doesn't work in your case, you can adjust the styling of the map
+container using the [`style`](#style-reactcssproperties) and
+[`className`](#classname-string) props.
+
+:::
 
 ## Controlled and Uncontrolled Props
 
@@ -70,6 +77,31 @@ enabled by the [`controlled` prop](#controlled-boolean). When this mode is
 active, the map will disable all control inputs and will reject to render
 anything not specified in the camera props.
 
+## Map Instance Caching
+
+If your application renders the map on a subpage or otherwise mounts and
+unmounts the `Map` component a lot, this can cause new map instances to be
+created with every mount of the component. Since the pricing of the Google
+Maps JavaScript API is based on map-views (effectively calls to the
+`google.maps.Map` constructor), this can quickly become a problem.
+
+The `Map` component can be configured to re-use already created maps with
+the `reuseMaps` prop. When enabled, all `Map` components created with the same
+`mapId` will reuse previously created instances instead of creating new ones.
+
+:::warning
+
+In the 1.0.0 version, support for map-caching is still a bit experimental, and
+there are some known issues when maps are being reused with different sets
+of options applied. In most simpler situations, like when showing the very
+same component multiple times, it should work fine.
+
+If you experience any problems using this feature, please file a [bug-report]
+[rgm-new-issue]
+or [start a discussion][rgm-discussions] on GitHub.
+
+:::
+
 ## Props
 
 The `MapProps` type extends the [`google.maps.MapOptions` interface][gmp-map-options]
@@ -106,6 +138,22 @@ A string that identifies the map component. This is required when multiple
 maps are present in the same APIProvider context to be able to access them using the
 [`useMap`](../hooks/use-map.md) hook.
 
+#### `mapId`: string
+
+The [Map ID][gmp-mapid] of the map. 
+
+:::info
+
+The Maps JavaScript API doesn't allow changing the Map ID of a map after it 
+has been created. This isn't the case for this component. However, the 
+internal `google.maps.Map` instance has to be recreated when the `mapId` prop 
+changes, which might cause additional cost. 
+
+See the [reuseMaps](#reusemaps-boolean) parameter if your application has to 
+repeatedly switch between multiple Map IDs.
+
+:::
+
 #### `style`: React.CSSProperties
 
 Additional style rules to apply to the map dom-element. By default, this will
@@ -116,6 +164,13 @@ only contain `{width: '100%', height: '100%'}`.
 Additional css class-name to apply to the element containing the map.
 When a classname is specified, the default width and height of the map from the
 style-prop is no longer applied.
+
+#### `reuseMaps`: boolean
+
+Enable map-instance caching for this component. When caching is enabled, 
+this component will reuse map instances created with the same `mapId`.
+
+See also the section [Map Instance Caching](#map-instance-caching) above.
 
 ### Camera Control
 
@@ -272,6 +327,9 @@ to get access to the `google.maps.Map` object rendered in the `<Map>` component.
 [gmp-llb]: https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngBoundsLiteral
 [gmp-ll]: https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngLiteral
 [gmp-coordinates]: https://developers.google.com/maps/documentation/javascript/coordinates
+[gmp-mapid]: https://developers.google.com/maps/documentation/get-map-id
 [api-provider]: ./api-provider.md
 [get-max-tilt]: https://github.com/visgl/react-google-maps/blob/4319bd3b68c40b9aa9b0ce7f377b52d20e824849/src/libraries/limit-tilt-range.ts#L4-L19
 [map-source]: https://github.com/visgl/react-google-maps/tree/main/src/components/map
+[rgm-new-issue]: https://github.com/visgl/react-google-maps/issues/new/choose
+[rgm-discussions]: https://github.com/visgl/react-google-maps/discussions

--- a/src/components/__tests__/map.test.tsx
+++ b/src/components/__tests__/map.test.tsx
@@ -109,7 +109,7 @@ describe('creating and updating map instance', () => {
     expect(createMapSpy).toHaveBeenCalled();
 
     const [actualEl, actualOptions] = createMapSpy.mock.lastCall!;
-    expect(actualEl).toBe(screen.getByTestId('map'));
+    expect(screen.getByTestId('map')).toContainElement(actualEl);
     expect(actualOptions).toMatchObject({
       center: {lat: 53.55, lng: 10.05},
       zoom: 12,

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -67,6 +67,11 @@ export type MapProps = google.maps.MapOptions &
      */
     controlled?: boolean;
 
+    /**
+     * Enable caching of map-instances created by this component.
+     */
+    reuseMaps?: boolean;
+
     defaultCenter?: google.maps.LatLngLiteral;
     defaultZoom?: number;
     defaultHeading?: number;


### PR DESCRIPTION
Introduces map-instance caching, allowing maps to be persisted across unmount/remount cycles.

Fixes #319 

BREAKING CHANGE: Introduction of map instance caching needed a change to the DOM-Structure produced by the map component (added a div-element owned by the Map component to contain the map instance).