### PR TITLE
feat(advanced-marker): remove content element in cleanup

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -107,8 +107,9 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
     setMarker(newMarker);
 
     // create the container for marker content if there are children
+    let contentElement: HTMLDivElement | null = null;
     if (numChildren > 0) {
-      const contentElement = document.createElement('div');
+      contentElement = document.createElement('div');
 
       newMarker.content = contentElement;
       setContentContainer(contentElement);
@@ -116,6 +117,7 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
 
     return () => {
       newMarker.map = null;
+      contentElement?.remove();
       setMarker(null);
       setContentContainer(null);
     };


### PR DESCRIPTION
In PR https://github.com/visgl/react-google-maps/pull/335, the `InfoWindow` cleanup function removes the content element. We should implement the same behavior for the `AdvancedMarker` component to ensure proper cleanup of its content element as well.

https://github.com/visgl/react-google-maps/blob/bc10a6f3a64e7445bc8b672375c9d196b7899d9e/src/components/info-window.tsx#L78-L83