### PR TITLE
fix(map): set container position to relative

### DIFF
--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -132,6 +132,7 @@ export function useMapInstance(
       } else {
         mapDiv = document.createElement('div');
         mapDiv.style.height = '100%';
+        mapDiv.style.position = 'relative';
         container.appendChild(mapDiv);
         map = new google.maps.Map(mapDiv, mapOptions);
       }


### PR DESCRIPTION
Introduction of the intermediate div with #349 indirectly broke relative positioning of elements withing the map-container.

Before that change, elements would be added to a container where position:relative was set by the Maps JavaScript API. This is no longer happening, so we need to set it ourselves.
