### PR TITLE
fix(map): set other container position to relative

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -169,6 +169,7 @@ export const Map = (props: PropsWithChildren<MapProps>) => {
     () => ({
       width: '100%',
       height: '100%',
+      position: 'relative',
       // when using deckgl, the map should be sent to the back
       zIndex: isDeckGlControlled ? -1 : 0,
 

--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -132,7 +132,6 @@ export function useMapInstance(
       } else {
         mapDiv = document.createElement('div');
         mapDiv.style.height = '100%';
-        mapDiv.style.position = 'relative';
         container.appendChild(mapDiv);
         map = new google.maps.Map(mapDiv, mapOptions);
       }


### PR DESCRIPTION
The change in #356 did the right thing, but added the position:relative to the wrong element.
