### PR TITLE
docs: update wording based on Google recommendation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Something does not work as expected
 title: '[Bug]'
-labels: bug
+labels: [bug]
 body:
   - type: markdown
     attributes:
@@ -11,7 +11,7 @@ body:
         Before reporting, please verify that you are using the latest version of the `@vis.gl/react-google-maps` library.
         
         You may find answers faster by searching in [the documentation](https://visgl.github.io/react-google-maps/search) and [existing issues](https://github.com/visgl/react-google-maps/issue).
-        If you are unsure whether it is a bug in your own implementation or the library itself, consider starting a conversation in [Discussions](https://github.com/visgl/react-map-gl/discussions) instead.
+        If you are unsure whether it is a bug in your own implementation or the library itself, consider starting a conversation in [Discussions](https://github.com/visgl/react-google-maps/discussions) instead.
   - type: textarea
     attributes:
       label: Description
@@ -38,7 +38,7 @@ body:
 
         Example:
           - **Library version**: @vis.gl/react-google-maps@1.0.0
-          - **Google maps version**: weekly (whatever is passed to the `version`
+          - **Google Maps JavaScript API version**: weekly (whatever is passed to the `version`
             prop of the APIProvider, default is 'weekly', ideally including the
             value of `google.maps.version`)
           - **Browser and Version**: Chrome 119.0
@@ -54,7 +54,11 @@ body:
   - type: textarea
     attributes:
       label: Logs
-      description: Please check the browser console for any relevant errors or warnings and post them here.
+      description: |
+        Please check the browser console for any relevant errors or warnings and post them here. 
+        
+        **Important**: stack traces can sometimes include your API-key as part of the script URLs, 
+        make sure to remove or replace them before submitting.
       render: text
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
-> [!IMPORTANT]
-> This project is still in its alpha phase.
->
-> When using it be aware that things may not yet work as expected and can
-> break at any point. Releases happen often, so when you experience problems,
-> make sure you are using the latest version (check with `npm outdated` in
-> your project) before opening an issue.
->
-> We are still in a phase where we can easily make bigger changes, so we ask
-> you to please [provide feedback](https://github.com/visgl/react-google-maps/issues/new)
-> on everything you notice - including, but not limited to
->
-> - developer experience (installation, typings, sourcemaps, framework integration, ...)
-> - hard to understand concepts and APIs
-> - wrong, missing, outdated or inaccurate documentation
-> - use-cases not covered by the API
-> - missing features
-> - and of course any bugs you encounter
->
-> Also, feel free to use [GitHub discussions](https://github.com/visgl/react-google-maps/discussions) to ask questions or start a new
-> discussion.
-
 # React Components for the Google Maps JavaScript API
 
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/visgl/react-google-maps/tree/main/LICENSE)
@@ -50,7 +28,7 @@ package name has to be quoted)_
 ## Usage
 
 Import the [`APIProvider`][api-provider] and wrap it around all components that should have
-access to the Google Maps API.
+access to the Maps JavaScript API.
 Any component within the context of the `APIProvider` can use the hooks and
 components provided by this library.
 
@@ -120,7 +98,7 @@ const MyComponent = () => {
 
 const App = () => {
   return (
-    <APIProvider apiKey={...}>
+    <APIProvider apiKey={'YOUR API KEY HERE'}>
       <MyComponent />
     </APIProvider>
   );
@@ -131,6 +109,35 @@ const App = () => {
 
 Explore our [examples directory on GitHub](./examples) or the
 [examples on our website][examples] for full implementation examples.
+
+## Terms of Service
+
+`@vis.gl/react-google-maps` uses Google Maps Platform services. Use of Google 
+Maps Platform services through this library is subject to the 
+[Google Maps Platform Terms of Service][gmp-tos].
+
+This library is not a Google Maps Platform Core Service. 
+Therefore, the Google Maps Platform Terms of Service (e.g., Technical 
+Support Services, Service Level Agreements, and Deprecation Policy) 
+do not apply to this library.
+
+## Support
+
+This library is offered via an open source license. It is not governed by the 
+Google Maps Platform [Support Technical Support Services Guidelines][gmp-tssg], 
+the [SLA][gmp-sla], or the [Deprecation Policy][gmp-dp] (however, any Google 
+Maps Platform services used by this library remain subject to the Google Maps 
+Platform Terms of Service).
+
+If you find a bug, or have a feature request, please [file an issue][rgm-issues]
+on GitHub. If you would like to get answers to technical questions from 
+other Google Maps Platform developers, feel free to open a thread in the 
+[discussions section on GitHub][rgm-discuss] or ask a question through one of 
+our [developer community channels][gmp-community].
+
+If you'd like to contribute, please check the [Contributing guide][rgm-contrib].
+
+You can also discuss this library on [our Discord server][gmp-discord].
 
 [api-provider]: https://visgl.github.io/react-google-maps/docs/api-reference/components/api-provider
 [api-map]: https://visgl.github.io/react-google-maps/docs/api-reference/components/map
@@ -143,3 +150,13 @@ Explore our [examples directory on GitHub](./examples) or the
 [gmp-services]: https://developers.google.com/maps/documentation/javascript#services
 [gmp-libraries]: https://developers.google.com/maps/documentation/javascript/libraries
 [npm-package]: https://www.npmjs.com/package/@vis.gl/react-google-maps
+[gmp-tos]: https://cloud.google.com/maps-platform/terms
+[gmp-tssg]: https://cloud.google.com/maps-platform/terms/tssg
+[gmp-sla]: https://cloud.google.com/maps-platform/terms/sla
+[gmp-dp]: https://cloud.google.com/maps-platform/terms/other/deprecation-policy
+[rgm-issues]: https://github.com/visgl/react-google-maps/issues
+[rgm-discuss]: https://github.com/visgl/react-google-maps/discussions
+[rgm-contrib]: https://visgl.github.io/react-google-maps/docs/contributing
+[gmp-community]: https://developers.google.com/maps/developer-community
+[gmp-discord]: https://discord.gg/f4hvx8Rp2q
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ to the map and any other component.
 Ultimately, in the spirit of the [reactive programming paradigm][wiki-reactive]
 used in React, data from this single source of truth should
 always flow down the component hierarchy. If components manage their own
-state, as Google Maps is designed to do, we risk the components going out of
+state, as Google maps are designed to do, we risk the components going out of
 sync.
 
 `@vis.gl/react-google-maps` provides a reactive wrapper for the Google Maps

--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -7,7 +7,7 @@ components and hooks of this library.
 It can be added at any level of the application (typically somewhere
 at the top of your component-tree), and it will render all child components
 unmodified. A re-render is only triggered once the loading status of the
-Google Maps API changes.
+Maps JavaScript API changes.
 
 Normally, there should only be a single instance of the APIProvider in a page,
 but there are situations (e.g., multiple React render-roots in a page) where
@@ -15,7 +15,7 @@ this isn't possible. In those cases, make sure to create all `APIProvider`
 components using the exact same props, since only the first one to
 render will actually load the maps API.
 
-When the Google Maps API has already been loaded externally
+When the Maps JavaScript API has already been loaded externally
 (i.e., the [`google.maps.importLibrary`][gmp-import-library] function exists),
 the
 `APIProvider` will ignore all specified props and use the existing
@@ -33,7 +33,7 @@ first render will in most cases have no effect, cause an error, or both.
 
 ## Usage
 
-The `APIProvider` only needs the [Google Maps API Key][gmp-api-keys] to function.
+The `APIProvider` only needs the [Google Maps Platform API Key][gmp-api-keys] to function.
 This has to be provided via the `apiKey` prop:
 
 ```tsx

--- a/docs/api-reference/components/info-window.md
+++ b/docs/api-reference/components/info-window.md
@@ -16,7 +16,7 @@ InfoWindow.
 :::note
 
 The rendered InfoWindow includes a close-button that can't be removed or
-controlled via the Google Maps API. This means that the application can't
+controlled via the Maps JavaScript API. This means that the application can't
 fully control the visibility of the InfoWindow.
 
 To keep your state in sync with the map, you have to provide a listener for the 

--- a/docs/api-reference/components/map.md
+++ b/docs/api-reference/components/map.md
@@ -1,6 +1,6 @@
 # `<Map>` Component
 
-React component to render a [Google Map][gmp-map]. It can be placed as a child
+React component to render a [Google map][gmp-map]. It can be placed as a child
 into any other component, but it has to be somewhere inside an
 [`<APIProvider>`][api-provider] container.
 
@@ -104,7 +104,7 @@ If you experience any problems using this feature, please file a
 ## Props
 
 The `MapProps` type extends the [`google.maps.MapOptions` interface][gmp-map-options]
-and includes all possible options available for a Google Map as props.
+and includes all possible options available for a Google map as props.
 
 The most important of these options are also listed below along with the
 properties added for the react-library.
@@ -189,7 +189,7 @@ is approximately:
 - `15`: Streets
 - `20`: Buildings
 
-The Google Maps API Documentation [has some more information on this topic][gmp-coordinates].
+The Maps JavaScript API Documentation [has some more information on this topic][gmp-coordinates].
 
 #### `heading`: number
 
@@ -239,14 +239,14 @@ const MapWithEventHandler = props => {
 };
 ```
 
-See [the table below](#mapping-of-google-maps-event-names-to-react-props)
+See [the table below](#mapping-of-maps-javascript-api-event-names-to-react-props)
 for the full list of events and corresponding prop names.
 
 All event callbacks receive a single argument of type `MapEvent` with the
 following properties and methods:
 
-- **`event.type`: string** The Google Maps event type of the event.
-- **`event.map`: google.maps.Map** The Map instance that dispatched the event.
+- **`event.type`: string** The event type of the event from the Maps JavaScript API.
+- **`event.map`: google.maps.Map** The map instance that dispatched the event.
 - **`event.stoppable`: boolean** Indicates if the event can be stopped in
   the event-handler. This is only the case for the `MapMouseEvent` type.
 - **`event.stop()`: () => void** for stoppable events, this will cause the
@@ -270,7 +270,7 @@ Based on the specific event, there is also additional information in the
   - **`placeId`: string | null** when a place marker on the map is clicked,
     this will contain the placeId of the Google Places API for that place.
 
-#### Mapping of Google Maps Event names to React props
+#### Mapping of Maps JavaScript API Event names to React props
 
 | Google Maps Event                 | React Prop                              | Event Type              |
 | --------------------------------- | --------------------------------------- | ----------------------- |

--- a/docs/api-reference/components/marker.md
+++ b/docs/api-reference/components/marker.md
@@ -20,7 +20,7 @@ export default App;
 
 ## Props
 
-The MarkerProps interface extends the [google.maps.MarkerOptions interface](https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerOptions) and includes all possible options available for a Google Maps Platform Marker. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
+The MarkerProps interface extends the [google.maps.MarkerOptions interface](https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerOptions) and includes all possible options available for a Maps JavaScript API Marker. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
 
 ```tsx
 interface MarkerProps extends google.maps.MarkerOptions {

--- a/docs/api-reference/hooks/use-map.md
+++ b/docs/api-reference/hooks/use-map.md
@@ -50,7 +50,6 @@ const MyComponent = () => {
 
     // do something with the map instance
   }, [map]);
-  // Do something with the Google Maps map instance
 
   return <>...</>;
 };

--- a/docs/api-reference/hooks/use-maps-library.md
+++ b/docs/api-reference/hooks/use-maps-library.md
@@ -1,6 +1,6 @@
 # `useMapsLibrary` Hook
 
-React hook to get access to the different [Google Maps API libraries][gmp-libraries].
+React hook to get access to the different [Maps JavaScript API libraries][gmp-libraries].
 This is essentially a react-version of the `google.maps.importLibrary` function.
 
 ```tsx

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,7 +23,7 @@ carefully.
 
 The focus will be on providing an extensible library of **"low-level"
 abstractions** that can be used to implement known and unknown use-cases of
-the Google Maps API in a React application.
+the Google Maps JavaScript API in a React application.
 
 In a lot of cases – especially when a solution needs to have a lot of
 flexibility (implementing an Autocomplete component for example) and room

--- a/docs/guides/deckgl-integration.md
+++ b/docs/guides/deckgl-integration.md
@@ -13,7 +13,7 @@ The following props need to be defined and passed to the DeckGL component:
 - `onViewStateChange`
 
 Make sure that the controller is always set to true and an initial view state is defined. To ensure that deck.gl works
-well with the Google Maps Platform map, set the `limitTiltRange` function, which can be imported from the Google Maps React
+well with the Google map, set the `limitTiltRange` function, which can be imported from `@vis.gl/react-gogle-maps`
 library, to `onViewStateChange`.
 
 ```tsx

--- a/docs/guides/interacting-with-google-maps-api.md
+++ b/docs/guides/interacting-with-google-maps-api.md
@@ -1,15 +1,15 @@
-# Interacting with the Google Maps API
+# Interacting with the Google Maps JavaScript API
 
 With the provided components, you are able to declaratively create a
-[Google Map](../api-reference/components/map.md) or a map with
+[Google map](../api-reference/components/map.md) or a map with
 [markers](../api-reference/components/marker.md) for example.
 
 Besides that, there are three main ways and concepts to interact
-with the Google Maps API on lower level with this library.
+with the Maps JavaScript API on lower level with this library.
 You can use the provided hooks, the refs that are available for
 some components or use the
 [`useMapsLibrary`](../api-reference/hooks/use-maps-library.md) hook
-to tap into other libraries and services of the Google Maps API or
+to tap into other libraries and services of the Maps JavaScript API or
 craft your own custom hooks.
 
 ## Hooks
@@ -47,7 +47,7 @@ const App = () => (
 ```
 
 The [useMapsLibrary](../api-reference/hooks/use-maps-library.md) hook can be
-utilized to load other parts of the Google Maps API that are not loaded by default.
+utilized to load other parts of the Maps JavaScript API that are not loaded by default.
 For example, the Places Service or the Geocoding Service.
 [Learn how to use this hook.](#other-google-maps-api-libraries-and-services)
 
@@ -92,7 +92,7 @@ const App = () => {
 export default App;
 ```
 
-## Other Google Maps API libraries and services
+## Other Maps JavaScript API libraries and services
 
 The Maps JavaScript API has a lot of [additional libraries](https://developers.google.com/maps/documentation/javascript/libraries)
 for things like geocoding, routing, the Places API, Street View, and

--- a/examples/_template/README.md
+++ b/examples/_template/README.md
@@ -1,11 +1,9 @@
-# Basic Google Maps Setup Example
-
-![image](https://user-images.githubusercontent.com/39244966/208682692-d5b23518-9e51-4a87-8121-29f71e41c777.png)
+# Example
 
 This is an example to show how to setup a simple Google Maps Map with the `<Map/>` component of the Google Maps React
 library.
 
-## Google Maps API key
+## Google Maps Platform API key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/autocomplete/README.md
+++ b/examples/autocomplete/README.md
@@ -6,9 +6,9 @@ Here you can find a few example implementations of the autocomplete functionalit
 
 We have three different implementations to demonstrate how to add autocomplete functionality to your application
 
-### 1) Google Maps Autocomplete Widget
+### 1) Maps JavaScript API Autocomplete Widget
 
-When using the [Google Maps Autocomplete widget][autocomplete-widget] you provide an HTML input element of your choice and Google handles all the rest. It will fetch predictions when the user types and it will get the details for a place when the user selects a prediction from the list.
+When using the [Autocomplete widget][autocomplete-widget] you provide an HTML input element of your choice and Google handles all the rest. It will fetch predictions when the user types and it will get the details for a place when the user selects a prediction from the list.
 
 ### 2) Custom Build
 
@@ -20,7 +20,7 @@ When building your own you are completely free but also responsible for the user
 
 This is basically the same as the custom build, except for not having to implement the list/dropdown/DOM handling yourself. A lot of third party text box widgets provide functionionality for handling keyboard navigation and focus handling. For the demo we used the [Combobox][combobox] from `react-widgets`.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key. For this example to work you also need to enable the `Places API` in your Google Cloud Console.

--- a/examples/autocomplete/src/autocomplete-alpha.tsx
+++ b/examples/autocomplete/src/autocomplete-alpha.tsx
@@ -1,4 +1,4 @@
-// NOTE: This requires the alpha version of the Google Maps API and is not yet
+// NOTE: This requires the alpha version of the Maps JavaScript API and is not yet
 // recommended to be used in production applications. We will add this to the example map
 // when it reaches GA (General Availability). Treat this as a preview of what's to come.
 

--- a/examples/autocomplete/src/control-panel.tsx
+++ b/examples/autocomplete/src/control-panel.tsx
@@ -18,7 +18,7 @@ function ControlPanel({
 
       <p>
         This example demonstrates three different methods of adding autocomplete
-        functionality to your appplication using the Google Maps Places API.
+        functionality to your appplication using the Google Places API.
       </p>
 
       <div className="autocomplete-mode">

--- a/examples/basic-map/README.md
+++ b/examples/basic-map/README.md
@@ -1,11 +1,10 @@
-# Basic Google Maps Setup Example
+# Basic Map Setup Example
 
 ![image](https://user-images.githubusercontent.com/39244966/208682692-d5b23518-9e51-4a87-8121-29f71e41c777.png)
 
-This is an example to show how to setup a simple Google Maps Map with the `<Map/>` component of the Google Maps React
-library.
+This is an example to show how to setup a simple Google map with the `<Map/>` component.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/basic-map/index.html
+++ b/examples/basic-map/index.html
@@ -5,10 +5,8 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, user-scalable=no" />
-    <title>Basic Google Maps Map Component Example</title>
-    <meta
-      name="description"
-      content="Basic Google Maps Map Component Example" />
+    <title>Basic Map Component Example</title>
+    <meta name="description" content="Basic Map Component Example" />
     <style>
       body {
         margin: 0;

--- a/examples/change-map-styles/README.md
+++ b/examples/change-map-styles/README.md
@@ -2,7 +2,7 @@
 
 This is an example to demonstrate changing the style of the `<Map/>` component using local and cloud-based map styles as well as map types.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/deckgl-overlay/README.md
+++ b/examples/deckgl-overlay/README.md
@@ -5,7 +5,7 @@ to a `<Map>` component. (using the `GoogleMapsOverlay` from [@deck.gl/google-map
 
 [@deck.gl/google-maps]: https://deck.gl/docs/api-reference/google-maps/overview
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/directions/README.md
+++ b/examples/directions/README.md
@@ -1,4 +1,4 @@
-# Basic Google Maps Setup Example
+# Google Maps Directions API Example
 
 ![image](https://raw.githubusercontent.com/visgl/react-google-maps/main/website/static/images/examples/directions.jpg)
 
@@ -6,7 +6,7 @@ This is an example which shows how to use `useMapsLibrary` to load the `routes` 
 
 It allows the user to choose alternative routes, updating the route being rendered on the map.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/drawing/README.md
+++ b/examples/drawing/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to use the [google.maps.drawing.DrawingManager][drawing-manager] to draw shapes or markers on the map. In addition the example implements an undo/redo flow for the drawing tools. If you only want to add the the drawing tools to your map take a look at the `use-drawing-manager` hook.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/drawing/src/control-panel.tsx
+++ b/examples/drawing/src/control-panel.tsx
@@ -5,9 +5,9 @@ function ControlPanel() {
     <div className="control-panel">
       <h3>Drawing Tools Example</h3>
       <p>
-        Shows how to use the Google Maps drawing tools and implements an
-        undo/redo flow to show how to integrate the drawing manager and its
-        events into the state of a react-application.
+        Shows how to use the drawing tools of the Maps JavaScript API and
+        implements an undo/redo flow to show how to integrate the drawing
+        manager and its events into the state of a react-application.
       </p>
       <div className="links">
         <a

--- a/examples/extended-component-library/README.md
+++ b/examples/extended-component-library/README.md
@@ -26,7 +26,7 @@ library remain subject to the Google Maps Platform Terms of Service). If you
 find a bug, or have a feature request, file an issue on the Github library
 site.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/geometry/README.md
+++ b/examples/geometry/README.md
@@ -2,13 +2,13 @@
 
 ![image](https://github.com/ArielBenichou/react-google-maps/assets/21100652/d32d7052-0ec0-4f2f-84a2-d31e6629dfa6)
 
-This is an example to show how to setup a Google Maps Map with some geometry component, notably the `<Circle />` and `<Polygon />` components.
+This is an example to show how to setup a Google map with some geometry component, notably the `<Circle />`, `<Polygon />` and `<Polyline />` components.
 
 ## Usage
 
-To use these components you just need to copy the components you want from the `src/components` folder, into your project.
+To use these components, you need to copy the components you want from the `src/components` folder into your project.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.
@@ -65,7 +65,7 @@ export default App;
 
 ### Props
 
-The CircleProps interface extends the [google.maps.CircleOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle) and includes all possible options available for a Google Maps Platform Circle. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
+The CircleProps interface extends the [google.maps.CircleOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle) and includes all possible options available for a Circle. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
 
 ```tsx
 interface CircleProps extends google.maps.CircleOptions {
@@ -115,7 +115,7 @@ export default App;
 
 ### Props
 
-The PolygonProps interface extends the [google.maps.PolygonOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polygon#Polygon) and includes all possible options available for a Google Maps Platform Polygon. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
+The PolygonProps interface extends the [google.maps.PolygonOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polygon#Polygon) and includes all possible options available for a Polygon. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
 
 ```tsx
 interface PolygonProps extends google.maps.PolygonOptions {
@@ -164,7 +164,7 @@ export default App;
 
 ### Props
 
-The PolylineProps interface extends the [google.maps.PolylineOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polyline#Polyline) and includes all possible options available for a Google Maps Platform Polyline. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
+The PolylineProps interface extends the [google.maps.PolylineOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polyline#Polyline) and includes all possible options available for a Polyline. Additionally, it is possible to add different event listeners, e.g. the click event with the `onClick` property.
 
 ```tsx
 interface PolylineProps extends google.maps.PolylineOptions {

--- a/examples/geometry/src/components/circle.tsx
+++ b/examples/geometry/src/components/circle.tsx
@@ -123,7 +123,7 @@ function useCircle(props: CircleProps) {
 }
 
 /**
- * Component to render a Google Maps Circle on a map
+ * Component to render a circle on a map
  */
 export const Circle = forwardRef((props: CircleProps, ref: CircleRef) => {
   const circle = useCircle(props);

--- a/examples/geometry/src/components/polygon.tsx
+++ b/examples/geometry/src/components/polygon.tsx
@@ -122,7 +122,7 @@ function usePolygon(props: PolygonProps) {
 }
 
 /**
- * Component to render a Google Maps polygon on a map
+ * Component to render a polygon on a map
  */
 export const Polygon = forwardRef((props: PolygonProps, ref: PolygonRef) => {
   const polygon = usePolygon(props);

--- a/examples/geometry/src/components/polyline.tsx
+++ b/examples/geometry/src/components/polyline.tsx
@@ -120,7 +120,7 @@ function usePolyline(props: PolylineProps) {
 }
 
 /**
- * Component to render a Google Maps polyline on a map
+ * Component to render a polyline on a map
  */
 export const Polyline = forwardRef((props: PolylineProps, ref: PolylineRef) => {
   const polyline = usePolyline(props);

--- a/examples/map-control/README.md
+++ b/examples/map-control/README.md
@@ -2,7 +2,7 @@
 
 This is an example to show how to add custom map-controls.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/marker-clustering/README.md
+++ b/examples/marker-clustering/README.md
@@ -4,7 +4,7 @@
 
 This is an example of how to use the [MarkerClusterer](https://github.com/googlemaps/js-markerclusterer) library from Google to cluster markers on a map.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/markers-and-infowindows/README.md
+++ b/examples/markers-and-infowindows/README.md
@@ -3,7 +3,7 @@
 Shows the different ways to use the `<Marker>`, `<AdvancedMarker>` and
 `<InfoWindow>` components.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/examples/multiple-maps/README.md
+++ b/examples/multiple-maps/README.md
@@ -3,7 +3,7 @@
 Shows how to use controlled mode and camera-events to synchronize
 multiple map instances.
 
-## Google Maps API key
+## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.
 See [the official documentation][get-api-key] on how to create and configure your own key.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vis.gl/react-google-maps",
   "version": "0.11.2",
-  "description": "React components and hooks for Google Maps.",
+  "description": "React components and hooks for the Google Maps JavaScript API",
   "source": "src/index.ts",
   "main": "dist/index.umd.js",
   "module": "dist/index.modern.mjs",
@@ -44,10 +44,11 @@
   ],
   "keywords": [
     "React",
-    "React components",
-    "React hooks",
+    "React Components",
+    "React Hooks",
     "Google Maps",
-    "Google Maps components"
+    "Google Maps JavaScript API",
+    "Maps"
   ],
   "dependencies": {
     "@types/google.maps": "^3.54.10",

--- a/src/components/__tests__/marker.test.tsx
+++ b/src/components/__tests__/marker.test.tsx
@@ -13,7 +13,7 @@ let wrapper: ({children}: {children: React.ReactNode}) => JSX.Element | null;
 let createMarkerSpy: jest.Mock;
 
 beforeEach(() => {
-  // initialize the Google Maps mock
+  // initialize the Maps JavaScript API mocks
   initialize();
 
   // Create wrapper component
@@ -43,7 +43,7 @@ afterEach(() => {
 test('marker should be initialized', async () => {
   render(<GoogleMapsMarker position={{lat: 1, lng: 2}} />, {wrapper});
 
-  // wait for Google Maps API to load and the marker to be created
+  // wait for Maps JavaScript API to load and the marker to be created
   await waitFor(() => expect(createMarkerSpy).toHaveBeenCalled());
 
   const markers = mockInstances.get(google.maps.Marker);
@@ -67,7 +67,7 @@ test('marker position should update when re-rendering', async () => {
     wrapper
   });
 
-  // wait for (mock) Google Maps API to load and the marker to be created
+  // wait for (mock) Maps JavaScript API to load and the marker to be created
   await waitFor(() => expect(createMarkerSpy).toHaveBeenCalled());
 
   const markers = mockInstances.get(google.maps.Marker);
@@ -88,7 +88,7 @@ test('marker should have a click listener', async () => {
     {wrapper}
   );
 
-  // wait for (mock) Google Maps API to load and the marker to be created
+  // wait for (mock) Maps JavaScript API to load and the marker to be created
   await waitFor(() => expect(createMarkerSpy).toHaveBeenCalled());
 
   const markerMocks = mockInstances.get(google.maps.Marker);

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -174,7 +174,10 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
             onLoad();
           }
         } catch (error) {
-          console.error('<ApiProvider> failed to load Google Maps API', error);
+          console.error(
+            '<ApiProvider> failed to load the Google Maps JavaScript API',
+            error
+          );
         }
       })();
     },
@@ -190,7 +193,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 }
 
 /**
- * Component to wrap the Google Maps React components and load the Google Maps JavaScript API
+ * Component to wrap the components from this library and load the Google Maps JavaScript API
  */
 export const APIProvider = (
   props: PropsWithChildren<APIProviderProps>

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -28,7 +28,7 @@ export type InfoWindowProps = Omit<
 };
 
 /**
- * Component to render a Google Maps Info Window
+ * Component to render an Info Window with the Maps JavaScript API
  */
 export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
   const {

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -44,7 +44,7 @@ export type MapCameraProps = {
 };
 
 /**
- * Props for the Google Maps Map Component
+ * Props for the Map Component
  */
 export type MapProps = google.maps.MapOptions &
   MapEventProps &

--- a/src/components/marker.tsx
+++ b/src/components/marker.tsx
@@ -116,7 +116,7 @@ function useMarker(props: MarkerProps) {
 }
 
 /**
- * Component to render a Google Maps Marker on a map
+ * Component to render a marker on a map
  */
 export const Marker = forwardRef((props: MarkerProps, ref: MarkerRef) => {
   const marker = useMarker(props);

--- a/src/components/pin.tsx
+++ b/src/components/pin.tsx
@@ -15,7 +15,7 @@ import {logErrorOnce} from '../libraries/errors';
 export type PinProps = google.maps.marker.PinElementOptions;
 
 /**
- * Component to render a google maps marker Pin View
+ * Component to configure the appearance of an AdvancedMarker
  */
 export const Pin = (props: PropsWithChildren<PinProps>) => {
   const advancedMarker = useContext(AdvancedMarkerContext)?.marker;

--- a/src/hooks/use-api-is-loaded.ts
+++ b/src/hooks/use-api-is-loaded.ts
@@ -1,7 +1,7 @@
 import {useApiLoadingStatus} from './use-api-loading-status';
 import {APILoadingStatus} from '../libraries/api-loading-status';
 /**
- * Hook to check if the Google Maps API is loaded
+ * Hook to check if the Maps JavaScript API is loaded
  */
 export function useApiIsLoaded(): boolean {
   const status = useApiLoadingStatus();

--- a/src/hooks/use-maps-event-listener.ts
+++ b/src/hooks/use-maps-event-listener.ts
@@ -2,7 +2,7 @@
 import {useEffect} from 'react';
 
 /**
- * Internally used to bind events to google maps API objects.
+ * Internally used to bind events to Maps JavaScript API objects.
  * @internal
  */
 export function useMapsEventListener<T extends (...args: any[]) => void>(

--- a/src/libraries/google-maps-api-loader.ts
+++ b/src/libraries/google-maps-api-loader.ts
@@ -37,7 +37,7 @@ export class GoogleMapsApiLoader {
   private static listeners: LoadingStatusCallback[] = [];
 
   /**
-   * Loads the Google Maps API with the specified parameters.
+   * Loads the Maps JavaScript API with the specified parameters.
    * Since the Maps library can only be loaded once per page, this will
    * produce a warning when called multiple times with different
    * parameters.

--- a/src/libraries/limit-tilt-range.ts
+++ b/src/libraries/limit-tilt-range.ts
@@ -19,7 +19,7 @@ const getMapMaxTilt = (zoom: number) => {
 };
 
 /**
- * Function to limit the tilt range of the google maps map when updating the view state
+ * Function to limit the tilt range of the Google map when updating the view state
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const limitTiltRange = ({viewState}: any) => {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,7 +10,7 @@ const {globSync} = require('glob');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'React Google Maps',
-  tagline: 'React wrapper for the Google Maps JavaScript API',
+  tagline: 'React components and hooks for the Google Maps JavaScript API',
   url: 'https://visgl.github.io/',
   baseUrl: '/react-google-maps/',
   onBrokenLinks: 'throw',


### PR DESCRIPTION
 - use 'Maps JavaScript API' or 'Google Maps JavaScript API' instead of 'Google Maps API' or other forms
 - use 'Google map(s)' when referring to maps in general
 - update some other brand related wordings
 - fixed some spelling and other issues