### PR TITLE
fix: set infowindow anchor to null during component unmount

### DIFF
--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -72,6 +72,9 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
       }
 
       // intentionally shadowing the state variables here
+      // the `anchor` property is not exposed directly by @types/google.maps but
+      // is present on the created InfoWindow object. Access to this property is
+      // needed to ensure proper cleanup of the InfoWindow
       const infoWindow = new google.maps.InfoWindow(
         infoWindowOptions
       ) as google.maps.InfoWindow & {anchor?: InfoWindowAnchor};

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -27,6 +27,11 @@ export type InfoWindowProps = Omit<
   onCloseClick?: () => void;
 };
 
+type InfoWindowAnchor =
+  | google.maps.MVCObject
+  | null
+  | google.maps.marker.AdvancedMarkerElement;
+
 /**
  * Component to render an Info Window with the Maps JavaScript API
  */
@@ -67,7 +72,9 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
       }
 
       // intentionally shadowing the state variables here
-      const infoWindow = new google.maps.InfoWindow(infoWindowOptions);
+      const infoWindow = new google.maps.InfoWindow(
+        infoWindowOptions
+      ) as google.maps.InfoWindow & {anchor?: InfoWindowAnchor};
       const contentContainer = document.createElement('div');
 
       infoWindow.setContent(contentContainer);
@@ -80,6 +87,7 @@ export const InfoWindow = (props: PropsWithChildren<InfoWindowProps>) => {
         google.maps.event.clearInstanceListeners(infoWindow);
 
         infoWindow.close();
+        infoWindow.anchor = null;
         contentContainer.remove();
         setInfoWindow(null);
         setContentContainer(null);


### PR DESCRIPTION
fix for https://github.com/visgl/react-google-maps/issues/386

I had to do a bit of type coercion as `@types/google.maps` doesn't actually expose all the properties on the resulting object when you create a new `google.maps.InfoWindow`