### PR TITLE
fix(info-window): fix reappearing InfoWindows

### DIFF
--- a/src/hooks/use-maps-event-listener.ts
+++ b/src/hooks/use-maps-event-listener.ts
@@ -15,6 +15,6 @@ export function useMapsEventListener<T extends (...args: any[]) => void>(
 
     const listener = google.maps.event.addListener(target, name, callback);
 
-    return () => listener?.remove();
+    return () => listener.remove();
   }, [target, name, callback]);
 }


### PR DESCRIPTION
An InfoWindow that is attached to a Marker or AdvancedMarker as anchor would occasionally show up again after being unmounted. This can happen when the anchor is removed from the map before the InfoWindow is unmounted but gets re-added to the map at a later point.

This is caused by intended behavior in the maps API, and the only workaround for this right now is to forcefully disconnect the InfoWindow from its anchor.

See here for more details: https://issuetracker.google.com/issues/343750849

Fixes #386

Co-Authored-By: Nick Schnelle <nick.schnelle@bupa.com.au>