### PR TITLE
Fix pin element overriding styling of advancedMarker

### DIFF
--- a/src/components/pin.tsx
+++ b/src/components/pin.tsx
@@ -58,7 +58,7 @@ export const Pin = (props: PropsWithChildren<PinProps>) => {
     }
 
     // Set content of Advanced Marker View to the Pin View element
-    advancedMarker.content = pinElement.element;
+    advancedMarker.content?.replaceChildren(pinElement.element);
   }, [advancedMarker, glyphContainer, props]);
 
   return createPortal(props.children, glyphContainer);


### PR DESCRIPTION
Solves [this](https://github.com/visgl/react-google-maps/discussions/368#discussioncomment-9811113) as requested by 
@usefulthink 