### PR TITLE
docs(examples): show more example tiles on small screen

### DIFF
--- a/website/src/components/example/styled.js
+++ b/website/src/components/example/styled.js
@@ -8,6 +8,9 @@ export const ExampleHeader = styled.div`
   border-bottom: 1px solid 20px;
   display: inline-block;
   padding: 20px 20px 4px 0;
+  ${isMobile} {
+      margin: 0;
+  }
 `;
 
 export const MainExamples = styled.main`
@@ -18,6 +21,9 @@ export const ExamplesGroup = styled.main`
   display: flex;
   flex-wrap: wrap;
   padding: 16px;
+  ${isMobile} {
+      padding-inline: 0;
+  }
 `;
 
 export const ExampleCard = styled.a`
@@ -42,7 +48,7 @@ export const ExampleCard = styled.a`
   }
   ${isMobile} {
     width: 33%;
-    min-width: 200px;
+    min-width: 150px;
   }
   @media screen and (max-width: 632px) {
     width: 50%;

--- a/website/src/components/example/styled.js
+++ b/website/src/components/example/styled.js
@@ -5,11 +5,10 @@ export const ExampleHeader = styled.div`
   font: bold 20px/28px var(--ifm-font-family-base);
   color: var(--ifm-color-content-secondary);
   margin: 0 20px;
-  border-bottom: 1px solid 20px;
   display: inline-block;
   padding: 20px 20px 4px 0;
   ${isMobile} {
-      margin: 0;
+    margin: 0;
   }
 `;
 
@@ -22,19 +21,20 @@ export const ExamplesGroup = styled.main`
   flex-wrap: wrap;
   padding: 16px;
   ${isMobile} {
-      padding-inline: 0;
+    padding-inline: 0;
   }
 `;
 
 export const ExampleCard = styled.a`
   cursor: pointer;
   text-decoration: none;
-  width: 50%;
-  max-width: 240px;
+  width: 240px;
+  max-width: 50%;
   line-height: 0;
   outline: none;
   padding: 4px;
   position: relative;
+
   img {
     transition-property: filter;
     transition-duration: var(--ifm-transition-slow);
@@ -46,11 +46,8 @@ export const ExampleCard = styled.a`
   &:hover img {
     filter: contrast(0.2);
   }
+
   ${isMobile} {
-    width: 33%;
-    min-width: 150px;
-  }
-  @media screen and (max-width: 632px) {
     width: 50%;
   }
 `;


### PR DESCRIPTION
Hello, this PR is an adjustment to the stylesheet for the example page so that more example tiles can be shown on the small screen, by shrinking extra margin/padding and adjusting the width of a tile.

Currently, even a relatively large-sized phone can only show only one thumbnail in a row.

## Before
![Screenshot from 2024-07-28 18-26-42](https://github.com/user-attachments/assets/575c9cd7-dbc4-46ab-90a4-f7d6c6cc0f0e)
![Screenshot from 2024-07-28 18-26-59](https://github.com/user-attachments/assets/e51080ac-c000-43c9-991a-9be860b2152c)


## After
![Screenshot from 2024-07-28 18-26-50](https://github.com/user-attachments/assets/9fd31707-7020-4c6c-b828-76e71b7b2f7f)
![Screenshot from 2024-07-28 18-27-06](https://github.com/user-attachments/assets/a07c93f7-437d-46e6-8cc6-1fa7144f9cfb)

## Desktop view
The desktop view remains the same.

### Before
![Screenshot from 2024-07-28 18-29-30](https://github.com/user-attachments/assets/856ab4b9-0154-49b3-a260-ae18b7c35914)

### After
![Screenshot from 2024-07-28 18-29-32](https://github.com/user-attachments/assets/58ba0d75-1fb3-41eb-bdaa-37261d600592)
