### PR TITLE
Add Support for Client ID as an Alternative to API Key for GMP Premium Plan

### DIFF
--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -33,8 +33,8 @@ first render will in most cases have no effect, cause an error, or both.
 
 ## Usage
 
-The `APIProvider` only needs the [Google Maps Platform API Key][gmp-api-keys] to function.
-This has to be provided via the `apiKey` prop:
+The `APIProvider` only needs the [Google Maps Platform API Key][gmp-api-keys] or [Client ID URL Authorization][gmp-client-id] to function.
+This has to be provided via the `apiKey` or `clientId` prop:
 
 ```tsx
 import React from 'react';
@@ -66,6 +66,18 @@ first render, later changes to the values will have no effect.
 #### `apiKey`: string (required, first-render only) {#apiKey}
 
 The API Key for the Maps JavaScript API.
+
+or
+
+#### `clientId`: string (required, first-render only) {#clientId}
+
+The Client ID for the Maps JavaScript API.
+
+:::note
+
+Request can not contain both `apiKey` and `clientId` at the same time.
+
+:::
 
 ### Optional
 
@@ -150,6 +162,7 @@ The following hooks are built to work with the `APIProvider` Component:
 
 [gmp-import-library]: https://developers.google.com/maps/documentation/javascript/load-maps-js-api#dynamic-library-import
 [gmp-api-keys]: https://developers.google.com/maps/documentation/javascript/get-api-key
+[gmp-client-id]: https://developers.google.com/maps/premium/authentication/client-id/url-authorization
 [gmp-params]: https://developers.google.com/maps/documentation/javascript/load-maps-js-api#required_parameters
 [gmp-api-version]: https://developers.google.com/maps/documentation/javascript/versions
 [gmp-libs]: https://developers.google.com/maps/documentation/javascript/libraries

--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -103,6 +103,13 @@ test("doesn't set solutionChannel when specified as empty string", () => {
   expect(actual).not.toHaveProperty('solutionChannel');
 });
 
+test('passes clientId to GoogleMapsAPILoader', () => {
+  render(<APIProvider clientId={'client-id'}></APIProvider>);
+
+  const actual = apiLoadSpy.mock.lastCall[0];
+  expect(actual).toMatchObject({client: 'client-id'});
+});
+
 test('renders inner components', async () => {
   const LoadingStatus = () => {
     const mapsLoaded = useApiIsLoaded();

--- a/src/libraries/google-maps-api-loader.ts
+++ b/src/libraries/google-maps-api-loader.ts
@@ -1,6 +1,12 @@
 import {APILoadingStatus} from './api-loading-status';
 
-type ApiCommonParams = {
+export type ApiParams = (
+  | {key?: string; client?: never}
+  | {
+      key?: never;
+      client?: string;
+    }
+) & {
   v?: string;
   language?: string;
   region?: string;
@@ -8,13 +14,6 @@ type ApiCommonParams = {
   solutionChannel?: string;
   authReferrerPolicy?: string;
 };
-
-export type ApiParams =
-  | ({key?: string; client?: never} & ApiCommonParams)
-  | ({
-      key?: never;
-      client?: string;
-    } & ApiCommonParams);
 
 type LoadingStatusCallback = (status: APILoadingStatus) => void;
 

--- a/src/libraries/google-maps-api-loader.ts
+++ b/src/libraries/google-maps-api-loader.ts
@@ -1,7 +1,6 @@
 import {APILoadingStatus} from './api-loading-status';
 
-export type ApiParams = {
-  key: string;
+type ApiCommonParams = {
   v?: string;
   language?: string;
   region?: string;
@@ -9,6 +8,13 @@ export type ApiParams = {
   solutionChannel?: string;
   authReferrerPolicy?: string;
 };
+
+export type ApiParams =
+  | ({key?: string; client?: never} & ApiCommonParams)
+  | ({
+      key?: never;
+      client?: string;
+    } & ApiCommonParams);
 
 type LoadingStatusCallback = (status: APILoadingStatus) => void;
 


### PR DESCRIPTION
This pull request adds support for using a [Client ID](https://developers.google.com/maps/premium/overview#client_id) in addition to the existing `apiKey` for the `APIProvider` component. 

While Google recommends using an `apiKey` for most users, there are specific scenarios and legacy systems where an enterprise `clientId` is necessary or beneficial such as specific contractual or billing arrangements.

### Component Changes:
* Modified `APIProviderProps` to support either `apiKey` or `clientId`, but not both simultaneously.
* Updated `useGoogleMapsApiLoader` to handle `clientId` in addition to `apiKey`. 

### Documentation Updates:
* Updated `docs/api-reference/components/api-provider.md` to include information about the new `clientId` prop and its usage. 

### Testing:
* Added a new test case to ensure `clientId` is correctly passed to `GoogleMapsAPILoader`.


