### PR TITLE
fix(map): undefined rendering-type and color-scheme

### DIFF
--- a/src/components/__tests__/map.test.tsx
+++ b/src/components/__tests__/map.test.tsx
@@ -110,7 +110,7 @@ describe('creating and updating map instance', () => {
 
     const [actualEl, actualOptions] = createMapSpy.mock.lastCall!;
     expect(screen.getByTestId('map')).toContainElement(actualEl);
-    expect(actualOptions).toMatchObject({
+    expect(actualOptions).toStrictEqual({
       center: {lat: 53.55, lng: 10.05},
       zoom: 12,
       mapId: 'mymapid'

--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -137,10 +137,15 @@ export function useMapInstance(
         mapDiv = document.createElement('div');
         mapDiv.style.height = '100%';
         container.appendChild(mapDiv);
+
         map = new google.maps.Map(mapDiv, {
           ...mapOptions,
-          renderingType: renderingType as google.maps.RenderingType,
-          colorScheme: colorScheme as google.maps.ColorScheme
+          ...(renderingType
+            ? {renderingType: renderingType as google.maps.RenderingType}
+            : {}),
+          ...(colorScheme
+            ? {colorScheme: colorScheme as google.maps.ColorScheme}
+            : {})
         });
       }
 


### PR DESCRIPTION
when color-scheme and/or rendering-type aren't specified, they were still passed as properties with undefined value to the google.maps.Map-constructor.

This is fixed here, along with the test that failed to detect that problem.