### PR TITLE
fix(types): add types-reference to google.maps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference types="google.maps" preserve="true" />
+
 export * from './components/advanced-marker';
 export * from './components/api-provider';
 export * from './components/info-window';


### PR DESCRIPTION
Typescript versions prior to 5.5 automatically emitted triple-slash directives for types used in the exported definitions. This was changed in 5.5, which could lead to situations where the google.maps types aren't properly picked up in a project using this package.

Adding a type-reference ourselves should help in those cases.

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit

fixes #519