### PR TITLE
feat: "onError" prop for api provider

### DIFF
--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -121,9 +121,7 @@ Read more in the [documentation][gmp-solutions-usage].
 a callback that is called once the Maps JavaScript
 API finished loading.
 
-### Error Handling
-
-#### `onError`: (error: Error) => void {#onError}
+#### `onError`: (error: unknown) => void {#onError}
 
 a callback that is called if there is an error loading
 the Google Maps JavaScript API.

--- a/docs/api-reference/components/api-provider.md
+++ b/docs/api-reference/components/api-provider.md
@@ -105,12 +105,12 @@ A list of [libraries][gmp-libs] to load immediately
 
 #### `solutionChannel`: string
 
-To help Google to better understand types of usage of the Google Maps 
-JavaScript API, the query parameter `solution_channel` can be set when 
-loading the API. 
+To help Google to better understand types of usage of the Google Maps
+JavaScript API, the query parameter `solution_channel` can be set when
+loading the API.
 
-The `@vis.gl/react-google-maps` library will by default set 
-this to a generic value unique to this library (`GMP_VISGL_react`). You may 
+The `@vis.gl/react-google-maps` library will by default set
+this to a generic value unique to this library (`GMP_VISGL_react`). You may
 opt out at any time by setting this prop to an empty string.
 Read more in the [documentation][gmp-solutions-usage].
 
@@ -120,6 +120,13 @@ Read more in the [documentation][gmp-solutions-usage].
 
 a callback that is called once the Maps JavaScript
 API finished loading.
+
+### Error Handling
+
+#### `onError`: (error: Error) => void {#onError}
+
+a callback that is called if there is an error loading
+the Google Maps JavaScript API.
 
 ## Context
 

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -82,7 +82,7 @@ export type APIProviderProps = {
   /**
    * A function that will be called if there was an error when loading the Google Maps JavaScript API.
    */
-  onError?: (error: Error) => void;
+  onError?: (error: unknown) => void;
 };
 
 /**
@@ -185,7 +185,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
             onLoad();
           }
         } catch (error) {
-          if (onError && error instanceof Error) {
+          if (onError) {
             onError(error);
           } else {
             console.error(

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -79,6 +79,10 @@ export type APIProviderProps = {
    * A function that can be used to execute code after the Google Maps JavaScript API has been loaded.
    */
   onLoad?: () => void;
+  /**
+   * A function that will be called if there was an error when loading the Google Maps JavaScript API.
+   */
+  onError?: (error: Error) => void;
 };
 
 /**
@@ -110,7 +114,14 @@ function useMapInstances() {
  * @param props
  */
 function useGoogleMapsApiLoader(props: APIProviderProps) {
-  const {onLoad, apiKey, version, libraries = [], ...otherApiParams} = props;
+  const {
+    onLoad,
+    onError,
+    apiKey,
+    version,
+    libraries = [],
+    ...otherApiParams
+  } = props;
 
   const [status, setStatus] = useState<APILoadingStatus>(
     GoogleMapsApiLoader.loadingStatus
@@ -174,10 +185,14 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
             onLoad();
           }
         } catch (error) {
-          console.error(
-            '<ApiProvider> failed to load the Google Maps JavaScript API',
-            error
-          );
+          if (onError && error instanceof Error) {
+            onError(error);
+          } else {
+            console.error(
+              '<ApiProvider> failed to load the Google Maps JavaScript API',
+              error
+            );
+          }
         }
       })();
     },


### PR DESCRIPTION
Resolves #533 

## Description

- Added onError to the list of API Provider props which will be called in case of an error when loading the Maps API. 
- Updated the mock in API Provider test to be able to simulate an error
- Added a unit test for the new functionality
- Added "Error Handling" section to the API Provider docs which mentions the new onError prop

I added the old console.error part to the else block so that there would be no error message in the console when running tests. 