### PR TITLE
fix: use deep compare effect to prevent infowindow close

### DIFF
--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -172,7 +172,7 @@ export const InfoWindow: FunctionComponent<
 
   // ## open info window when content and map are available
   const map = useMap();
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     // `anchor === null` means an anchor is defined but not ready yet.
     if (!map || !infoWindow || anchor === null) return;
 


### PR DESCRIPTION
The `infowindowOptions`  was a new object on every render thus resulting in the infowindow getting closed when the map was panned or zoomed

addresses #628 