### PR TITLE
Improve map ColorScheme and RenderingType types

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -51,14 +51,14 @@ export const ColorScheme = {
   DARK: 'DARK',
   LIGHT: 'LIGHT',
   FOLLOW_SYSTEM: 'FOLLOW_SYSTEM'
-};
+} as const;
 export type ColorScheme = (typeof ColorScheme)[keyof typeof ColorScheme];
 
 export const RenderingType = {
   VECTOR: 'VECTOR',
   RASTER: 'RASTER',
   UNINITIALIZED: 'UNINITIALIZED'
-};
+} as const;
 export type RenderingType = (typeof RenderingType)[keyof typeof RenderingType];
 
 /**


### PR DESCRIPTION
Changed the ColorScheme and RenderingType types to use const to avoid being inferred as a string instead of the literal value.