### PR TITLE
chore: add internalUsageAttributionIds in the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ const App = () => {
   );
 };
 ```
+### Internal usage attribution ID
+
+This library uses [`internalUsageAttributionIds`](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.internalUsageAttributionIds), which helps Google understand which libraries and
+samples are helpful to developers and is optional.
+
+To opt-out, use
+```
+<APIProvider useInternalUsageAttributionId=false>
+  <MyComponent />
+</APIProvider>
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ samples are helpful to developers and is optional.
 
 To opt-out, use
 ```
-<APIProvider useInternalUsageAttributionId=false>
+<APIProvider useInternalUsageAttributionIds=false>
   <MyComponent />
 </APIProvider>
 ```

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -5,14 +5,14 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
-  useState
+  useState,
 } from 'react';
 
+import {APILoadingStatus} from '../libraries/api-loading-status';
 import {
   ApiParams,
-  GoogleMapsApiLoader
+  GoogleMapsApiLoader,
 } from '../libraries/google-maps-api-loader';
-import {APILoadingStatus} from '../libraries/api-loading-status';
 
 type ImportLibraryFunction = typeof google.maps.importLibrary;
 type GoogleMapsLibrary = Awaited<ReturnType<ImportLibraryFunction>>;
@@ -29,6 +29,9 @@ export interface APIProviderContextValue {
 }
 
 const DEFAULT_SOLUTION_CHANNEL = 'GMP_visgl_rgmlibrary_v1_default';
+const DEFAULT_INTERNAL_USAGE_ATTRIBUTION_IDS = [
+  'GMP_LIB_VISGL_REACT_GOOGLE_MAPS',
+];
 
 export const APIProviderContext =
   React.createContext<APIProviderContextValue | null>(null);
@@ -82,6 +85,12 @@ export type APIProviderProps = PropsWithChildren<{
    */
   solutionChannel?: string;
   /**
+   * To help Google understand which libraries and samples are helpful to developers, such as usage of this library. To opt out of sending the usage attribution ID, it is safe to set this to `false`.
+   * Read more in the
+   * [documentation](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.internalUsageAttributionIds)
+   */
+  useInternalUsageAttributionIds?: boolean;
+  /**
    * A function that can be used to execute code after the Google Maps JavaScript API has been loaded.
    */
   onLoad?: () => void;
@@ -100,7 +109,7 @@ function useMapInstances() {
   >({});
 
   const addMapInstance = (mapInstance: google.maps.Map, id = 'default') => {
-    setMapInstances(instances => ({...instances, [id]: mapInstance}));
+    setMapInstances((instances) => ({...instances, [id]: mapInstance}));
   };
 
   const removeMapInstance = (id = 'default') => {
@@ -126,28 +135,29 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
     apiKey,
     version,
     libraries = [],
+    useInternalUsageAttributionIds = true,
     ...otherApiParams
   } = props;
 
   const [status, setStatus] = useState<APILoadingStatus>(
-    GoogleMapsApiLoader.loadingStatus
+    GoogleMapsApiLoader.loadingStatus,
   );
   const [loadedLibraries, addLoadedLibrary] = useReducer(
     (
       loadedLibraries: LoadedLibraries,
-      action: {name: keyof LoadedLibraries; value: LoadedLibraries[string]}
+      action: {name: keyof LoadedLibraries; value: LoadedLibraries[string]},
     ) => {
       return loadedLibraries[action.name]
         ? loadedLibraries
         : {...loadedLibraries, [action.name]: action.value};
     },
-    {}
+    {},
   );
 
   const librariesString = useMemo(() => libraries?.join(','), [libraries]);
   const serializedParams = useMemo(
     () => JSON.stringify({apiKey, version, ...otherApiParams}),
-    [apiKey, version, otherApiParams]
+    [apiKey, version, otherApiParams],
   );
 
   const importLibrary: typeof google.maps.importLibrary = useCallback(
@@ -159,7 +169,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
       if (!google?.maps?.importLibrary) {
         throw new Error(
           '[api-provider-internal] importLibrary was called before ' +
-            'google.maps.importLibrary was defined.'
+            'google.maps.importLibrary was defined.',
         );
       }
 
@@ -168,7 +178,15 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 
       return res;
     },
-    [loadedLibraries]
+    [loadedLibraries],
+  );
+
+  const internalUsageAttributionIds = useMemo(
+    () =>
+      useInternalUsageAttributionIds
+        ? DEFAULT_INTERNAL_USAGE_ATTRIBUTION_IDS
+        : [],
+    [useInternalUsageAttributionIds],
   );
 
   useEffect(
@@ -190,7 +208,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
             params.solutionChannel = DEFAULT_SOLUTION_CHANNEL;
           else if (params.solutionChannel === '') delete params.solutionChannel;
 
-          await GoogleMapsApiLoader.load(params, status => setStatus(status));
+          await GoogleMapsApiLoader.load(params, (status) => setStatus(status));
 
           for (const name of ['core', 'maps', ...libraries]) {
             await importLibrary(name);
@@ -205,32 +223,33 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
           } else {
             console.error(
               '<ApiProvider> failed to load the Google Maps JavaScript API',
-              error
+              error,
             );
           }
         }
       })();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [apiKey, librariesString, serializedParams]
+    [apiKey, librariesString, serializedParams],
   );
 
   return {
     status,
     loadedLibraries,
-    importLibrary
+    importLibrary,
+    internalUsageAttributionIds,
   };
 }
 
 /**
  * Component to wrap the components from this library and load the Google Maps JavaScript API
  */
-export const APIProvider: FunctionComponent<APIProviderProps> = props => {
+export const APIProvider: FunctionComponent<APIProviderProps> = (props) => {
   const {children, ...loaderProps} = props;
   const {mapInstances, addMapInstance, removeMapInstance, clearMapInstances} =
     useMapInstances();
 
-  const {status, loadedLibraries, importLibrary} =
+  const {status, loadedLibraries, importLibrary, internalUsageAttributionIds} =
     useGoogleMapsApiLoader(loaderProps);
 
   const contextValue: APIProviderContextValue = useMemo(
@@ -241,7 +260,8 @@ export const APIProvider: FunctionComponent<APIProviderProps> = props => {
       clearMapInstances,
       status,
       loadedLibraries,
-      importLibrary
+      importLibrary,
+      internalUsageAttributionIds
     }),
     [
       mapInstances,
@@ -250,8 +270,9 @@ export const APIProvider: FunctionComponent<APIProviderProps> = props => {
       clearMapInstances,
       status,
       loadedLibraries,
-      importLibrary
-    ]
+      importLibrary,
+      internalUsageAttributionIds
+    ],
   );
 
   return (

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -185,7 +185,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
     () =>
       useInternalUsageAttributionIds
         ? DEFAULT_INTERNAL_USAGE_ATTRIBUTION_IDS
-        : [],
+        : null,
     [useInternalUsageAttributionIds],
   );
 

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -5,14 +5,14 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
-  useState,
+  useState
 } from 'react';
 
-import {APILoadingStatus} from '../libraries/api-loading-status';
 import {
   ApiParams,
-  GoogleMapsApiLoader,
+  GoogleMapsApiLoader
 } from '../libraries/google-maps-api-loader';
+import {APILoadingStatus} from '../libraries/api-loading-status';
 
 type ImportLibraryFunction = typeof google.maps.importLibrary;
 type GoogleMapsLibrary = Awaited<ReturnType<ImportLibraryFunction>>;
@@ -109,7 +109,7 @@ function useMapInstances() {
   >({});
 
   const addMapInstance = (mapInstance: google.maps.Map, id = 'default') => {
-    setMapInstances((instances) => ({...instances, [id]: mapInstance}));
+    setMapInstances(instances => ({...instances, [id]: mapInstance}));
   };
 
   const removeMapInstance = (id = 'default') => {
@@ -140,24 +140,24 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
   } = props;
 
   const [status, setStatus] = useState<APILoadingStatus>(
-    GoogleMapsApiLoader.loadingStatus,
+    GoogleMapsApiLoader.loadingStatus
   );
   const [loadedLibraries, addLoadedLibrary] = useReducer(
     (
       loadedLibraries: LoadedLibraries,
-      action: {name: keyof LoadedLibraries; value: LoadedLibraries[string]},
+      action: {name: keyof LoadedLibraries; value: LoadedLibraries[string]}
     ) => {
       return loadedLibraries[action.name]
         ? loadedLibraries
         : {...loadedLibraries, [action.name]: action.value};
     },
-    {},
+    {}
   );
 
   const librariesString = useMemo(() => libraries?.join(','), [libraries]);
   const serializedParams = useMemo(
     () => JSON.stringify({apiKey, version, ...otherApiParams}),
-    [apiKey, version, otherApiParams],
+    [apiKey, version, otherApiParams]
   );
 
   const importLibrary: typeof google.maps.importLibrary = useCallback(
@@ -169,7 +169,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
       if (!google?.maps?.importLibrary) {
         throw new Error(
           '[api-provider-internal] importLibrary was called before ' +
-            'google.maps.importLibrary was defined.',
+            'google.maps.importLibrary was defined.'
         );
       }
 
@@ -178,7 +178,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
 
       return res;
     },
-    [loadedLibraries],
+    [loadedLibraries]
   );
 
   const internalUsageAttributionIds = useMemo(
@@ -208,7 +208,7 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
             params.solutionChannel = DEFAULT_SOLUTION_CHANNEL;
           else if (params.solutionChannel === '') delete params.solutionChannel;
 
-          await GoogleMapsApiLoader.load(params, (status) => setStatus(status));
+          await GoogleMapsApiLoader.load(params, status => setStatus(status));
 
           for (const name of ['core', 'maps', ...libraries]) {
             await importLibrary(name);
@@ -223,28 +223,28 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
           } else {
             console.error(
               '<ApiProvider> failed to load the Google Maps JavaScript API',
-              error,
+              error
             );
           }
         }
       })();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [apiKey, librariesString, serializedParams],
+    [apiKey, librariesString, serializedParams]
   );
 
   return {
     status,
     loadedLibraries,
     importLibrary,
-    internalUsageAttributionIds,
+    internalUsageAttributionIds
   };
 }
 
 /**
  * Component to wrap the components from this library and load the Google Maps JavaScript API
  */
-export const APIProvider: FunctionComponent<APIProviderProps> = (props) => {
+export const APIProvider: FunctionComponent<APIProviderProps> = props => {
   const {children, ...loaderProps} = props;
   const {mapInstances, addMapInstance, removeMapInstance, clearMapInstances} =
     useMapInstances();

--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -101,6 +101,8 @@ export function useMapInstance(
   if (!mapOptions.tilt && Number.isFinite(defaultTilt))
     mapOptions.tilt = defaultTilt;
 
+  mapOptions.internalUsageAttributionIds = context.internalUsageAttributionIds;
+
   for (const key of Object.keys(mapOptions) as (keyof typeof mapOptions)[])
     if (mapOptions[key] === undefined) delete mapOptions[key];
 


### PR DESCRIPTION
This PR add internalUsageAttributionId to help Google understand which libraries and samples are helpful to developers, such as usage of this library. Instructions for opting out of the identifier are provided in README.

The value is assign as part of APIProvider context and passed to maps instance to pass to mapOptions.