### PR TITLE
[FEATURE] Draggable Directions example

### DIFF
--- a/examples/directions/README.md
+++ b/examples/directions/README.md
@@ -6,6 +6,8 @@ This is an example which shows how to use `useMapsLibrary` to load the `routes` 
 
 It allows the user to choose alternative routes, updating the route being rendered on the map.
 
+Users can also drag the markers around the map to change the route. The route is updated in real-time.
+
 ## Google Maps Platform API Key
 
 This example does not come with an API key. Running the examples locally requires a valid API key for the Google Maps Platform.

--- a/examples/directions/src/app.tsx
+++ b/examples/directions/src/app.tsx
@@ -39,8 +39,31 @@ function Directions() {
   useEffect(() => {
     if (!routesLibrary || !map) return;
     setDirectionsService(new routesLibrary.DirectionsService());
-    setDirectionsRenderer(new routesLibrary.DirectionsRenderer({map}));
+    setDirectionsRenderer(
+      new routesLibrary.DirectionsRenderer({
+        draggable: true, // Only necessary for draggable markers
+        map
+      })
+    );
   }, [routesLibrary, map]);
+
+  // Add the following useEffect to make markers draggable
+  useEffect(() => {
+    if (!directionsRenderer) return;
+
+    // Add the listener to update routes when directions change
+    const listener = directionsRenderer.addListener(
+      'directions_changed',
+      () => {
+        const result = directionsRenderer.getDirections();
+        if (result) {
+          setRoutes(result.routes);
+        }
+      }
+    );
+
+    return () => google.maps.event.removeListener(listener);
+  }, [directionsRenderer]);
 
   // Use directions service
   useEffect(() => {


### PR DESCRIPTION
Implemented draggable map markers into the Directions example. Added comments into code to specify what is necessary for draggable directions. Mentioned feature in README. 

This will close #672 

![draggable-directions-example](https://github.com/user-attachments/assets/059f6d73-d379-472a-a25b-952c5ace38da)
