### PR TITLE
fix: 3d map not loading correctly due to new parameter mode=hybrid not included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /examples/**/node_modules
 /examples/**/dist
 /examples/**/.env*
+.vscode/

--- a/examples/map-3d/src/map-3d/map-3d.tsx
+++ b/examples/map-3d/src/map-3d/map-3d.tsx
@@ -70,7 +70,8 @@ export const Map3D = forwardRef(
         range={props.range}
         heading={props.heading}
         tilt={props.tilt}
-        roll={props.roll}></gmp-map-3d>
+        roll={props.roll}
+        mode="hybrid"></gmp-map-3d>
     );
   }
 );


### PR DESCRIPTION
On Fri 21 Feb, Google Maps released a breaking change that required mode="hybrid" added to the  <gmp-map-3d/> component. This change fixed that.