### PR TITLE
Allow negative anchor values for AdvancedMarker

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -127,10 +127,15 @@ const MarkerContent = ({
 }: MarkerContentProps) => {
   const [xTranslation, yTranslation] =
     anchorPoint ?? AdvancedMarkerAnchorPoint['BOTTOM'];
+ 
+  let xTranslationFlipped = `-${xTranslation}`;
+  let yTranslationFlipped = `-${yTranslation}`;
+  if(xTranslation.trimStart().startsWith('-')) { xTranslationFlipped = xTranslation.substring(1); }
+  if(yTranslation.trimStart().startsWith('-')) { yTranslationFlipped = yTranslation.substring(1); }
 
   // The "translate(50%, 100%)" is here to counter and reset the default anchoring of the advanced marker element
   // that comes from the api
-  const transformStyle = `translate(50%, 100%) translate(-${xTranslation}, -${yTranslation})`;
+  const transformStyle = `translate(50%, 100%) translate(${xTranslationFlipped}, ${yTranslationFlipped})`;
 
   return (
     // anchoring container


### PR DESCRIPTION
Allow negative anchor values for AdvancedMarker, so it can be placed entirely below or to the right of the marker position.