### PR TITLE
fix: ensure proper type inference of APILoadingStatus

### DIFF
--- a/src/libraries/api-loading-status.ts
+++ b/src/libraries/api-loading-status.ts
@@ -4,6 +4,6 @@ export const APILoadingStatus = {
   LOADED: 'LOADED',
   FAILED: 'FAILED',
   AUTH_FAILURE: 'AUTH_FAILURE'
-};
+} as const;
 export type APILoadingStatus =
   (typeof APILoadingStatus)[keyof typeof APILoadingStatus];


### PR DESCRIPTION
Added `as const` to ensure that `APILoadingStatus` is the intended union type instead of `string`