### PR TITLE
refactor: no `Node` type casting

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -221,9 +221,10 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
   // we set the className directly on the marker.content element that comes
   // with the AdvancedMarker.
   useEffect(() => {
-    if (!marker || !marker.content || numChildren > 0) return;
+    if (!marker?.content || !isElementNode(marker.content) || numChildren > 0)
+      return;
 
-    (marker.content as HTMLElement).className = className || '';
+    marker.content.className = className ?? '';
   }, [marker, className, numChildren]);
 
   // copy other props


### PR DESCRIPTION
## Why are we doing this?

Because there is a type predicate already, so we can [keep things consistent](https://github.com/visgl/react-google-maps/blob/42602d6c20d29b176c8e97ee568a9665aac69309/src/components/advanced-marker.tsx#L224).