### PR TITLE
docs: fix place-ui-kit example

### DIFF
--- a/examples/places-ui-kit/src/app.tsx
+++ b/examples/places-ui-kit/src/app.tsx
@@ -23,7 +23,7 @@ export type PlaceType =
   | 'electric_vehicle_charging_station'
   | null;
 
-export type DetailsSize = 'SMALL' | 'MEDIUM' | 'LARGE' | 'X_LARGE';
+export type DetailsSize = 'FULL' | 'COMPACT';
 
 const MAP_CONFIG = {
   defaultZoom: 15,
@@ -50,7 +50,7 @@ const App = () => {
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
   const [locationId, setLocationId] = useState<string | null>(null);
   const [placeType, setPlaceType] = useState<PlaceType>('restaurant');
-  const [detailsSize, setDetailsSize] = useState<DetailsSize>('MEDIUM');
+  const [detailsSize, setDetailsSize] = useState<DetailsSize>('FULL');
 
   // Memoize the place markers to prevent unnecessary re-renders
   // Only recreate when places, selection, or details size changes

--- a/examples/places-ui-kit/src/components/place-details-marker.tsx
+++ b/examples/places-ui-kit/src/components/place-details-marker.tsx
@@ -33,21 +33,6 @@ export const PlaceDetailsMarker = memo(
       onClick(null);
     }, [onClick]);
 
-    // Configure the place details element with place data when it's mounted
-    const handlePlaceDetailsRef = useCallback(
-      (placeDetailsElement: any) => {
-        if (!placeDetailsElement) return;
-
-        try {
-          // Connect the web component to the place data
-          placeDetailsElement.configureFromPlace(place);
-        } catch (error) {
-          console.error('Error configuring place details:', error);
-        }
-      },
-      [place]
-    );
-
     // Configure the elevation element with the place's geographic coordinates
     const handleElevationRef = useCallback(
       (elevationElement: any) => {
@@ -80,11 +65,27 @@ export const PlaceDetailsMarker = memo(
             maxWidth={400}
             headerDisabled={true}>
             {/* 
-              gmp-place-details is a Google Maps Web Component that displays detailed information
-              about a place, including photos, reviews, open hours, etc.
-              The size parameter controls how much information is displayed.
-            */}
-            <gmp-place-details size={detailsSize} ref={handlePlaceDetailsRef} />
+             gmp-place-details is a Google Maps Web Component that displays detailed information
+             about a place, including photos, reviews, open hours, etc.
+             The size parameter controls how much information is displayed.
+             
+             
+             gmp-place-details-compact is a Google Maps Web Component that displays a lot of the same
+             information as the full version but in a more compact format.
+           */}
+            {detailsSize === 'FULL' ? (
+              <gmp-place-details>
+                <gmp-place-details-place-request
+                  place={place?.id ?? ''}></gmp-place-details-place-request>
+                <gmp-place-all-content></gmp-place-all-content>
+              </gmp-place-details>
+            ) : (
+              <gmp-place-details-compact>
+                <gmp-place-details-place-request
+                  place={place?.id ?? ''}></gmp-place-details-place-request>
+                <gmp-place-all-content></gmp-place-all-content>
+              </gmp-place-details-compact>
+            )}
 
             <br />
             {/* 
@@ -115,6 +116,28 @@ declare module 'react' {
         },
         // @ts-expect-error PlaceDetailsElement not in types yet
         google.maps.places.PlaceDetailsElement
+      >;
+      'gmp-place-details-compact': React.DetailedHTMLProps<
+        // @ts-expect-error PlaceDetailsCompactElement not in types yet
+        React.HTMLAttributes<google.maps.places.PlaceDetailsCompactElement> & {
+          size?: any;
+        },
+        // @ts-expect-error PlaceDetailsCompactElement not in types yet
+        google.maps.places.PlaceDetailsCompactElement
+      >;
+      'gmp-place-details-place-request': React.DetailedHTMLProps<
+        // @ts-expect-error PlaceDetailsPlaceRequestElement not in types yet
+        React.HTMLAttributes<google.maps.places.PlaceDetailsPlaceRequestElement> & {
+          place: string;
+        },
+        // @ts-expect-error PlaceDetailsPlaceRequestElement not in types yet
+        google.maps.places.PlaceDetailsPlaceRequestElement
+      >;
+      'gmp-place-all-content': React.DetailedHTMLProps<
+        // @ts-expect-error PlaceAllContentElement not in types yet
+        React.HTMLAttributes<google.maps.places.PlaceAllContentElement>,
+        // @ts-expect-error PlaceAllContentElement not in types yet
+        google.maps.places.PlaceAllContentElement
       >;
     }
   }

--- a/examples/places-ui-kit/src/control-panel.tsx
+++ b/examples/places-ui-kit/src/control-panel.tsx
@@ -29,10 +29,8 @@ function ControlPanel(props: ControlPanelProps) {
         onChange={event => {
           props.onDetailSizeChange(event.target.value as DetailsSize);
         }}>
-        <option value="SMALL">Small</option>
-        <option value="MEDIUM">Medium</option>
-        <option value="LARGE">Large</option>
-        <option value="X_LARGE">X-Large</option>
+        <option value="FULL">Full</option>
+        <option value="COMPACT">Compact</option>
       </select>
       <div className="links">
         <a


### PR DESCRIPTION
The `configureFromPlace` function i no longer available.
The `size` option is no longer available on the `gmp-place-details` element.

- Refactor size dropdown to only have FULL/COMPACT options. Using `gmp-place-details`  for FULL and `gmp-place-details-compact` for COMPACT
- Configure component with webcomponent rather than the `configureFromPlace` function.
- Using `gmp-place-all-content` element to display all default options for both scenarios.