### PR TITLE
fix: Update calc clusters to happen after Idle event - reduces issue 563

### DIFF
--- a/examples/custom-marker-clustering/src/hooks/use-map-viewport.ts
+++ b/examples/custom-marker-clustering/src/hooks/use-map-viewport.ts
@@ -15,7 +15,7 @@ export function useMapViewport({padding = 0}: MapViewportOptions = {}) {
   useEffect(() => {
     if (!map) return;
 
-    const listener = map.addListener('bounds_changed', () => {
+    const listener = map.addListener('idle', () => {
       const bounds = map.getBounds();
       const zoom = map.getZoom();
       const projection = map.getProjection();


### PR DESCRIPTION
### Summary

This PR updates the `custom-marker-clustering` example to delay cluster rendering until the map becomes idle, rather than reacting to every `bounds_changed` event during zoom.

### Motivation

While investigating [issue #563](https://github.com/visgl/react-google-maps/issues/563), I found that the aggressive re-clustering during zoom gestures may contribute to a rare but severe bug where the zoom level resets unexpectedly (sometimes to zero). This is especially noticeable with a large number of markers. See [comment](https://github.com/visgl/react-google-maps/issues/563#issuecomment-3128047435).

By aligning the behavior with how Google’s official `[js-markerclusterer](https://github.com/googlemaps/js-markerclusterer)`(https://github.com/googlemaps/js-markerclusterer) handles clustering (listening to the `idle` event), we reduce the likelihood of triggering this issue and improve performance during zoom gestures.
