### PR TITLE
feat: add internalUsageAttributionIds support (#1234)

### DIFF
--- a/src/components/__tests__/api-provider.test.tsx
+++ b/src/components/__tests__/api-provider.test.tsx
@@ -195,3 +195,33 @@ test('calls onError when loading the Google Maps JavaScript API fails', async ()
 
   expect(onErrorMock).toHaveBeenCalled();
 });
+
+describe('internalUsageAttributionIds', () => {
+  test('provides default attribution IDs in context', () => {
+    render(
+      <APIProvider apiKey={'apikey'}>
+        <ContextSpyComponent />
+      </APIProvider>
+    );
+
+    const contextSpy = ContextSpyComponent.spy;
+    const actualContext: APIProviderContextValue = contextSpy.mock.lastCall[0];
+
+    expect(actualContext.internalUsageAttributionIds).toEqual([
+      'GMP_LIB_VISGL_REACT_GOOGLE_MAPS'
+    ]);
+  });
+
+  test('sets internalUsageAttributionIds to null when disableUsageAttribution is true', () => {
+    render(
+      <APIProvider apiKey={'apikey'} disableUsageAttribution>
+        <ContextSpyComponent />
+      </APIProvider>
+    );
+
+    const contextSpy = ContextSpyComponent.spy;
+    const actualContext: APIProviderContextValue = contextSpy.mock.lastCall[0];
+
+    expect(actualContext.internalUsageAttributionIds).toBeNull();
+  });
+});

--- a/src/components/__tests__/map.test.tsx
+++ b/src/components/__tests__/map.test.tsx
@@ -26,7 +26,8 @@ beforeEach(() => {
     mapInstances: {},
     addMapInstance: jest.fn(),
     removeMapInstance: jest.fn(),
-    clearMapInstances: jest.fn()
+    clearMapInstances: jest.fn(),
+    internalUsageAttributionIds: null
   };
 
   wrapper = ({children}) => (
@@ -113,7 +114,8 @@ describe('creating and updating map instance', () => {
     expect(actualOptions).toStrictEqual({
       center: {lat: 53.55, lng: 10.05},
       zoom: 12,
-      mapId: 'mymapid'
+      mapId: 'mymapid',
+      internalUsageAttributionIds: null
     });
 
     // should register the map-instance in the context
@@ -276,4 +278,71 @@ describe('camera configuration', () => {
 
 describe('map events and event-props', () => {
   test.todo('events dispatched by the map are received via event-props');
+});
+
+describe('internalUsageAttributionIds', () => {
+  test('uses default attribution IDs from context', () => {
+    mockContextValue.internalUsageAttributionIds = [
+      'GMP_LIB_VISGL_REACT_GOOGLE_MAPS'
+    ];
+
+    render(<GoogleMap zoom={8} center={{lat: 53.55, lng: 10.05}} />, {wrapper});
+
+    const [, options] = createMapSpy.mock.lastCall!;
+    expect(options).toMatchObject({
+      internalUsageAttributionIds: ['GMP_LIB_VISGL_REACT_GOOGLE_MAPS']
+    });
+  });
+
+  test('uses null from context when disableUsageAttribution is set', () => {
+    mockContextValue.internalUsageAttributionIds = null;
+
+    render(<GoogleMap zoom={8} center={{lat: 53.55, lng: 10.05}} />, {wrapper});
+
+    const [, options] = createMapSpy.mock.lastCall!;
+    expect(options).toBeDefined();
+    expect(options?.internalUsageAttributionIds).toBeNull();
+  });
+
+  test('appends custom attribution IDs to default IDs', () => {
+    mockContextValue.internalUsageAttributionIds = [
+      'GMP_LIB_VISGL_REACT_GOOGLE_MAPS'
+    ];
+
+    render(
+      <GoogleMap
+        zoom={8}
+        center={{lat: 53.55, lng: 10.05}}
+        internalUsageAttributionIds={['CUSTOM_ID_1', 'CUSTOM_ID_2']}
+      />,
+      {wrapper}
+    );
+
+    const [, options] = createMapSpy.mock.lastCall!;
+    expect(options).toMatchObject({
+      internalUsageAttributionIds: [
+        'GMP_LIB_VISGL_REACT_GOOGLE_MAPS',
+        'CUSTOM_ID_1',
+        'CUSTOM_ID_2'
+      ]
+    });
+  });
+
+  test('uses only custom IDs when context is disabled', () => {
+    mockContextValue.internalUsageAttributionIds = null;
+
+    render(
+      <GoogleMap
+        zoom={8}
+        center={{lat: 53.55, lng: 10.05}}
+        internalUsageAttributionIds={['CUSTOM_ID_1', 'CUSTOM_ID_2']}
+      />,
+      {wrapper}
+    );
+
+    const [, options] = createMapSpy.mock.lastCall!;
+    expect(options).toMatchObject({
+      internalUsageAttributionIds: ['CUSTOM_ID_1', 'CUSTOM_ID_2']
+    });
+  });
 });

--- a/src/components/api-provider.tsx
+++ b/src/components/api-provider.tsx
@@ -26,9 +26,13 @@ export interface APIProviderContextValue {
   addMapInstance: (map: google.maps.Map, id?: string) => void;
   removeMapInstance: (id?: string) => void;
   clearMapInstances: () => void;
+  internalUsageAttributionIds: string[] | null;
 }
 
 const DEFAULT_SOLUTION_CHANNEL = 'GMP_visgl_rgmlibrary_v1_default';
+const DEFAULT_INTERNAL_USAGE_ATTRIBUTION_IDS = [
+  'GMP_LIB_VISGL_REACT_GOOGLE_MAPS'
+];
 
 export const APIProviderContext =
   React.createContext<APIProviderContextValue | null>(null);
@@ -68,7 +72,8 @@ export type APIProviderProps = PropsWithChildren<{
    */
   authReferrerPolicy?: string;
   /**
-   * To track usage of Google Maps JavaScript API via numeric channels. The only acceptable channel values are numbers from 0-999.
+   * To track usage of Google Maps JavaScript API via numeric channels.
+   * The only acceptable channel values are numbers from 0-999.
    * Read more in the
    * [documentation](https://developers.google.com/maps/reporting-and-monitoring/reporting#usage-tracking-per-channel)
    */
@@ -81,6 +86,12 @@ export type APIProviderProps = PropsWithChildren<{
    * [documentation](https://developers.google.com/maps/reporting-and-monitoring/reporting#solutions-usage).
    */
   solutionChannel?: string;
+  /**
+   * To help Google understand which libraries and samples are helpful to developers, such as usage of this library.
+   * To opt out of sending the usage attribution ID, use this boolean prop. Read more in the
+   * [documentation](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.internalUsageAttributionIds).
+   */
+  disableUsageAttribution?: boolean;
   /**
    * A function that can be used to execute code after the Google Maps JavaScript API has been loaded.
    */
@@ -221,6 +232,18 @@ function useGoogleMapsApiLoader(props: APIProviderProps) {
   };
 }
 
+function useInternalUsageAttributionIds(props: APIProviderProps) {
+  const internalUsageAttributionIds = useMemo(
+    () =>
+      props.disableUsageAttribution
+        ? null
+        : DEFAULT_INTERNAL_USAGE_ATTRIBUTION_IDS,
+    [props.disableUsageAttribution]
+  );
+
+  return internalUsageAttributionIds;
+}
+
 /**
  * Component to wrap the components from this library and load the Google Maps JavaScript API
  */
@@ -232,6 +255,9 @@ export const APIProvider: FunctionComponent<APIProviderProps> = props => {
   const {status, loadedLibraries, importLibrary} =
     useGoogleMapsApiLoader(loaderProps);
 
+  const internalUsageAttributionIds =
+    useInternalUsageAttributionIds(loaderProps);
+
   const contextValue: APIProviderContextValue = useMemo(
     () => ({
       mapInstances,
@@ -240,7 +266,8 @@ export const APIProvider: FunctionComponent<APIProviderProps> = props => {
       clearMapInstances,
       status,
       loadedLibraries,
-      importLibrary
+      importLibrary,
+      internalUsageAttributionIds
     }),
     [
       mapInstances,
@@ -249,7 +276,8 @@ export const APIProvider: FunctionComponent<APIProviderProps> = props => {
       clearMapInstances,
       status,
       loadedLibraries,
-      importLibrary
+      importLibrary,
+      internalUsageAttributionIds
     ]
   );
 

--- a/src/components/map/use-map-instance.ts
+++ b/src/components/map/use-map-instance.ts
@@ -101,6 +101,21 @@ export function useMapInstance(
   if (!mapOptions.tilt && Number.isFinite(defaultTilt))
     mapOptions.tilt = defaultTilt;
 
+  // Handle internalUsageAttributionIds
+  const customIds = mapOptions.internalUsageAttributionIds;
+
+  if (customIds == null) {
+    // Not specified - use context default (which may be null if disabled)
+    mapOptions.internalUsageAttributionIds =
+      context.internalUsageAttributionIds;
+  } else {
+    // Merge context defaults with custom IDs
+    mapOptions.internalUsageAttributionIds = [
+      ...(context.internalUsageAttributionIds || []),
+      ...customIds
+    ];
+  }
+
   for (const key of Object.keys(mapOptions) as (keyof typeof mapOptions)[])
     if (mapOptions[key] === undefined) delete mapOptions[key];
 

--- a/src/hooks/__tests__/api-loading.test.tsx
+++ b/src/hooks/__tests__/api-loading.test.tsx
@@ -23,7 +23,8 @@ beforeEach(() => {
     mapInstances: {},
     addMapInstance: jest.fn(),
     removeMapInstance: jest.fn(),
-    clearMapInstances: jest.fn()
+    clearMapInstances: jest.fn(),
+    internalUsageAttributionIds: null
   };
 
   wrapper = ({children}) => (

--- a/src/hooks/__tests__/use-map.test.tsx
+++ b/src/hooks/__tests__/use-map.test.tsx
@@ -29,7 +29,8 @@ beforeEach(() => {
     mapInstances: {},
     addMapInstance: jest.fn(),
     removeMapInstance: jest.fn(),
-    clearMapInstances: jest.fn()
+    clearMapInstances: jest.fn(),
+    internalUsageAttributionIds: null
   };
 
   MockApiContextProvider = ({children}) => (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
       "@vis.gl/react-google-maps": ["./src"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./types/**/*"],
   "exclude": ["./dist", "./node_modules"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./types/**/*"],
   "exclude": ["./examples/**/*"],
   "compilerOptions": {
     "noEmit": false

--- a/types/google.maps.d.ts
+++ b/types/google.maps.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Type extensions for @types/google.maps to include newer properties
+ * not yet available in the published type definitions.
+ */
+
+declare namespace google.maps {
+  interface MapOptions {
+    /**
+     * Attribution IDs for internal usage tracking.
+     * @see https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.internalUsageAttributionIds
+     */
+    internalUsageAttributionIds?: Iterable<string> | null;
+  }
+}


### PR DESCRIPTION
- Extend MapOptions type to include internalUsageAttributionIds
- Implement default and custom attribution ID handling in APIProvider and GoogleMap components
- Add tests for internalUsageAttributionIds behavior
- Update TypeScript configurations to include custom type definition
