### PR TITLE
fix: respect clickable prop in AdvancedMarker

### DIFF
--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -301,11 +301,12 @@ function useAdvancedMarker(props: AdvancedMarkerProps) {
   useEffect(() => {
     if (!marker) return;
 
+    // when clickable is defined, we will always use its value for gmpClickable.
+    // otherwise we auto-detect based on existing event-handlers.
     const gmpClickable =
-      clickable !== undefined ||
-      Boolean(onClick) ||
-      Boolean(onMouseEnter) ||
-      Boolean(onMouseLeave);
+      clickable !== undefined
+        ? clickable
+        : Boolean(onClick) || Boolean(onMouseEnter) || Boolean(onMouseLeave);
 
     // gmpClickable is only available in beta version of the
     // maps api (as of 2024-10-10)


### PR DESCRIPTION
## Description
This PR fixes an issue where the `AdvancedMarker` remains clickable even when the `clickable` prop is explicitly set to `false`. 

As discussed in #904 , the current logic for `gmpClickable` incorrectly evaluates to `true` if `clickable` is defined as `false`. I have updated the logic to properly respect the boolean value of the prop.

## Related Issue
Closes #904 

## Changes
- Updated the `gmpClickable` calculation in `advanced-marker.tsx` to ensure it only evaluates to `true` when `clickable` is actually `true` (or when interaction callbacks are present).

## How to Test
1. Render an `AdvancedMarker` with `clickable={false}`.
2. Verify that the `gmp-clickable` attribute is not applied (or set to false) in the DOM.
3. Confirm that the marker no longer intercepts click events, allowing them to propagate to the map.