### PR TITLE
feat(map-control): add className prop

### DIFF
--- a/docs/api-reference/components/map-control.md
+++ b/docs/api-reference/components/map-control.md
@@ -45,5 +45,14 @@ const App = () => (
 The position is specified as one of the values of the `ControlPosition` enum, which
 is an exact copy of the [`google.maps.ControlPosition`][gmp-ctrl-pos] type.
 
+### Optional
+
+#### `className`: string
+
+A CSS class name applied to the container element that wraps the control content
+on the map. This is useful for styling or targeting the control from outside,
+since the children are rendered into a container that is managed by the Maps
+JavaScript API rather than directly into the React tree.
+
 [gmp-custom-ctrl]: https://developers.google.com/maps/documentation/javascript/controls#CustomControls
 [gmp-ctrl-pos]: https://developers.google.com/maps/documentation/javascript/controls#ControlPositioning

--- a/src/components/__tests__/map-control.test.tsx
+++ b/src/components/__tests__/map-control.test.tsx
@@ -39,3 +39,53 @@ test('control is added to the map', () => {
   const [controlEl] = (controlsArray.push as jest.Mock).mock.calls[0];
   expect(controlEl).toHaveTextContent('control button');
 });
+
+test('className prop is applied to the control container', () => {
+  render(
+    <MapControl
+      position={ControlPosition.BOTTOM_CENTER}
+      className="custom-control">
+      <button>control button</button>
+    </MapControl>
+  );
+
+  const controlsArray = mapInstance.controls[ControlPosition.BOTTOM_CENTER];
+  const [controlEl] = (controlsArray.push as jest.Mock).mock.calls[0];
+
+  expect(controlEl).toHaveClass('custom-control');
+});
+
+test('className prop updates are reflected on the control container', () => {
+  const {rerender} = render(
+    <MapControl
+      position={ControlPosition.BOTTOM_CENTER}
+      className="initial-class">
+      <button>control button</button>
+    </MapControl>
+  );
+
+  const controlsArray = mapInstance.controls[ControlPosition.BOTTOM_CENTER];
+  const [controlEl] = (controlsArray.push as jest.Mock).mock.calls[0];
+
+  expect(controlEl).toHaveClass('initial-class');
+
+  rerender(
+    <MapControl
+      position={ControlPosition.BOTTOM_CENTER}
+      className="updated-class">
+      <button>control button</button>
+    </MapControl>
+  );
+
+  expect(controlEl).toHaveClass('updated-class');
+  expect(controlEl).not.toHaveClass('initial-class');
+
+  rerender(
+    <MapControl position={ControlPosition.BOTTOM_CENTER}>
+      <button>control button</button>
+    </MapControl>
+  );
+
+  expect(controlEl).not.toHaveClass('updated-class');
+  expect(controlEl).not.toHaveClass('initial-class');
+});

--- a/src/components/map-control.tsx
+++ b/src/components/map-control.tsx
@@ -6,6 +6,7 @@ import type {PropsWithChildren} from 'react';
 
 type MapControlProps = PropsWithChildren<{
   position: ControlPosition;
+  className?: string;
 }>;
 
 /**
@@ -48,10 +49,16 @@ export type ControlPosition =
 
 export const MapControl: FunctionComponent<MapControlProps> = ({
   children,
-  position
+  position,
+  className
 }) => {
   const controlContainer = useMemo(() => document.createElement('div'), []);
   const map = useMap();
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/immutability -- the control container DOM node is intentionally mutated from effects
+    controlContainer.className = className ?? '';
+  }, [controlContainer, className]);
 
   useEffect(() => {
     if (!map) return;


### PR DESCRIPTION
## Summary

Adds an optional `className` prop to `<MapControl>` so users can style the control container element. Since `MapControl` renders its children into a detached `<div>` via `createPortal` (which is then handed to the Maps JavaScript API and positioned by the control-layout algorithm), there is currently no way for consumers to target that wrapping element from the React tree - the new prop closes that gap.

The implementation mirrors the existing `className` handling in sibling components (`AdvancedMarker`, `InfoWindow`): an effect syncs the prop to the DOM node as `controlContainer.className = className ?? ''`.

## Changes

- `src/components/map-control.tsx` — add optional `className` prop and a `useEffect` that syncs it to the portal container.
- `src/components/__tests__/map-control.test.tsx` — add unit tests covering initial application, updates, and unset/removal of `className`.
- `docs/api-reference/components/map-control.md` — document the new prop under an "Optional" section.

## Test plan

- [x] `npm run test:linter` passes
- [x] `npm run test:prettier` passes
- [x] `npm run test:tsc` passes
- [x] `npm run test:unit -- map-control` — 3/3 tests pass (1 existing + 2 new)
- [x] Full `npm run test:unit` suite: no new failures introduced (pre-existing `ts-jest` failures on `main` are unrelated to this change)

## Notes for reviewers

- No breaking changes; prop is optional and defaults to unset.
- API mirrors `className` on other components in the library for consistency.
- Happy to open a Discussion first if the maintainers prefer that flow for small additive props like this one — just let me know.