### PR TITLE
chore(deps): replace fast-deep-equal with fast-equals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@googlemaps/js-api-loader": "^2.0.2",
         "@types/google.maps": "^3.64.0",
-        "fast-deep-equal": "^3.1.3"
+        "fast-equals": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -4930,7 +4930,17 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.0.2",
     "@types/google.maps": "^3.64.0",
-    "fast-deep-equal": "^3.1.3"
+    "fast-equals": "^5.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",

--- a/src/components/circle.tsx
+++ b/src/components/circle.tsx
@@ -5,7 +5,7 @@ import React, {
   useState
 } from 'react';
 
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 import {useMap} from '../hooks/use-map';
 import {useMapsEventListener} from '../hooks/use-maps-event-listener';

--- a/src/components/info-window.tsx
+++ b/src/components/info-window.tsx
@@ -9,7 +9,7 @@ import React, {
   useState
 } from 'react';
 import {createPortal} from 'react-dom';
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 import {useMap} from '../hooks/use-map';
 import {useMapsEventListener} from '../hooks/use-maps-event-listener';

--- a/src/components/polygon.tsx
+++ b/src/components/polygon.tsx
@@ -6,7 +6,7 @@ import React, {
   useState
 } from 'react';
 
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 import {useMap} from '../hooks/use-map';
 import {useMapsLibrary} from '../hooks/use-maps-library';

--- a/src/components/polyline.tsx
+++ b/src/components/polyline.tsx
@@ -6,7 +6,7 @@ import React, {
   useState
 } from 'react';
 
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 import {useMap} from '../hooks/use-map';
 import {useMapsLibrary} from '../hooks/use-maps-library';

--- a/src/components/rectangle.tsx
+++ b/src/components/rectangle.tsx
@@ -5,7 +5,7 @@ import React, {
   useState
 } from 'react';
 
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 import {useMap} from '../hooks/use-map';
 import {useMapsEventListener} from '../hooks/use-maps-event-listener';

--- a/src/hooks/use-deep-compare-effect.ts
+++ b/src/hooks/use-deep-compare-effect.ts
@@ -1,6 +1,6 @@
 import {DependencyList, EffectCallback} from 'react';
 import {useCustomCompareEffect} from './use-custom-compare-efffect';
-import isDeepEqual from 'fast-deep-equal';
+import {deepEqual as isDeepEqual} from 'fast-equals';
 
 export function useDeepCompareEffect(
   effect: EffectCallback,


### PR DESCRIPTION
## Summary

`fast-deep-equal` (the previous dependency) hasn't been updated since 2020 and ships only a CommonJS build, so consumers that go through ESM toolchains pay a small interop cost for what is effectively a single deep-equality function. `fast-equals` is actively maintained, ships ESM + CJS, and the `deepEqual` export has the same `(a, b) -> boolean` shape as the default export of `fast-deep-equal`. `@googlemaps/markerclusterer` made the same swap recently in googlemaps/js-markerclusterer#893, which is what the issue points at.

This PR swaps the dependency in `package.json` (`fast-deep-equal ^3.1.3` -> `fast-equals ^5.0.0`) and updates every `src/` import to pull `deepEqual` from `fast-equals`. The local binding stays `isDeepEqual` via the rename-on-import form, so every call site is unchanged. That keeps the call-site diff to zero lines and the behavior identical.

Touched imports:

- `src/hooks/use-deep-compare-effect.ts`
- `src/components/circle.tsx`
- `src/components/info-window.tsx`
- `src/components/polygon.tsx`
- `src/components/polyline.tsx`
- `src/components/rectangle.tsx`

## Why this matters

ESM-first toolchains (and the project's own Rollup build) handle pure-ESM libraries better than legacy CJS-only ones; removing the last unmaintained CJS-only dependency from the runtime tree means one fewer interop seam to debug when the project itself moves toward ESM consumers. The package is also smaller and faster on the benchmarks the `fast-equals` maintainer publishes, though the practical delta for the use-deep-compare-effect path is negligible. The maintenance signal is the real motivation.

## Verification

Locally on a clean install:

    npm install                  # resolves fast-equals 5.4.0
    npm run test:tsc             # passes (tsc --project tsconfig.test.json --noEmit)
    npm run test:unit            # Test Suites: 18 passed, 18 total; Tests: 135 passed, 13 todo, 1 skipped

No behavioral changes at any call site; the rename-on-import keeps every existing reference to `isDeepEqual` working unchanged.

Closes #755

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.
