### PR TITLE
ci: add plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+      - uses: getplumber/plumber@e81ed4965fd92e0d2b63e95d399ed0419f5de2fa # v0.4.36
         with:
           # Code scanning upload needs security-events write, which PRs
           # from forks do not get. The report stays available as a

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,14 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    # Off for now: the release jobs restore the npm cache through
+    # setup-node on release triggers. Scoping the cache key to the
+    # release ref (or skipping the cache on publish) is a good
+    # follow-up, but it is its own change.
+    releaseWorkflowsMustNotRestoreUntrustedCache:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Components for the Google Maps JavaScript API
 
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/visgl/react-google-maps/tree/main/LICENSE)
+[![Plumber Score](https://score.getplumber.io/github.com/visgl/react-google-maps.svg)](https://score.getplumber.io/github.com/visgl/react-google-maps)
 
 This is a TypeScript / JavaScript library to integrate the Maps JavaScript API
 into your React application.


### PR DESCRIPTION
Companion to https://github.com/visgl/react-google-maps/pull/1040, merge that one first: the check added here flags the unpinned action and the missing permissions blocks until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to main and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, an archived dependency, a known CVE, that kind of thing.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the security tab as SARIF (skipped on PRs from forks, the report stays as an artifact there).
- `.plumber.yaml`: a 14 line overlay that inherits the CLI's built-in baseline, you only see what differs for this repo: one control is off with a comment saying why (the release jobs restore the npm cache on release triggers, scoping that cache key is a good follow-up but its own change). Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge under the license one.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of main. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, the hardening PR is the one that matters and it stands on its own.