### PR TITLE
fix(advanced-marker): only assign anchorLeft/anchorTop when provided

### DIFF
--- a/src/components/__tests__/advanced-marker.test.tsx
+++ b/src/components/__tests__/advanced-marker.test.tsx
@@ -253,6 +253,54 @@ describe('map and marker-library loaded', () => {
       (google.maps as any).version = '3.62.9';
     });
 
+    // Regression test for issue #867: when the consumer provides only
+    // `anchorTop` (or only `anchorLeft`), the library must not assign
+    // `undefined` to the unspecified side. Doing so clobbers the
+    // default value the Google Maps JS API sets up, and combined with
+    // `gmpDraggable = true` the API subsequently throws
+    // `TypeError: Failed to execute 'appendChild' on 'Node'` while
+    // wiring up the drag handle.
+    test('only the provided anchor prop is assigned, the other side is left untouched (#867)', async () => {
+      // The mock AdvancedMarkerElement is a plain class extending the
+      // jest-mocks HTMLElement; it does not pre-define `anchorLeft` /
+      // `anchorTop` on instances. Therefore, when the library assigns
+      // `undefined` to the unprovided side, an own property with
+      // value `undefined` is created. After the fix, that own property
+      // must NOT exist because the library must not touch the side the
+      // consumer did not provide.
+      const {unmount} = render(
+        <AdvancedMarker position={{lat: 0, lng: 0}} anchorTop={'-90%'}>
+          <div />
+        </AdvancedMarker>
+      );
+
+      const marker = await waitForMockInstance(
+        google.maps.marker.AdvancedMarkerElement
+      );
+      expect(marker.anchorTop).toBe('-90%');
+      // After the fix: anchorLeft must remain unset (no own property).
+      expect(
+        Object.getOwnPropertyDescriptor(marker, 'anchorLeft')
+      ).toBeUndefined();
+
+      unmount();
+
+      render(
+        <AdvancedMarker position={{lat: 0, lng: 0}} anchorLeft={'10px'}>
+          <div />
+        </AdvancedMarker>
+      );
+
+      const marker2 = await waitForMockInstance(
+        google.maps.marker.AdvancedMarkerElement
+      );
+      expect(marker2.anchorLeft).toBe('10px');
+      // After the fix: anchorTop must remain unset (no own property).
+      expect(
+        Object.getOwnPropertyDescriptor(marker2, 'anchorTop')
+      ).toBeUndefined();
+    });
+
     test('anchorLeft/anchorTop should have precedence over anchorPoint', async () => {
       const consoleWarnSpy = jest
         .spyOn(console, 'warn')

--- a/src/components/advanced-marker.tsx
+++ b/src/components/advanced-marker.tsx
@@ -365,8 +365,14 @@ function useAdvancedMarkerAnchoring(
         );
       }
 
-      marker.anchorLeft = anchorLeft;
-      marker.anchorTop = anchorTop;
+      // Only assign properties that were actually provided by the consumer.
+      // Assigning `undefined` to `anchorLeft`/`anchorTop` would clobber the
+      // element's default value, and the Google Maps JS API can subsequently
+      // fail with a `TypeError: Failed to execute 'appendChild' on 'Node'`
+      // when it later reads these properties while setting up drag handles
+      // (see issue #867).
+      if (anchorLeft !== undefined) marker.anchorLeft = anchorLeft;
+      if (anchorTop !== undefined) marker.anchorTop = anchorTop;
 
       // when anchorLeft and/or anchorTop are set, we'll ignore the anchorPoint
       if (anchorPoint !== undefined) {


### PR DESCRIPTION
Fixes #867

## Summary

When the consumer supplied only one of `anchorLeft` or `anchorTop` to `<AdvancedMarker>`, `useAdvancedMarkerAnchoring` unconditionally assigned `undefined` to the other side, clobbering the default value the Google Maps JS API had set up on the underlying `AdvancedMarkerElement`. Combined with `gmpDraggable = true`, the API subsequently threw

```
TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'
```

while wiring up the drag handle.

The fix only assigns each property when the consumer actually provided it, leaving the unprovided side untouched.

## Reproduction

```jsx
<AdvancedMarker
  position={{lat: 0, lng: 0}}
  draggable
  anchorTop="-90%"
>
  <img src="pin.svg" alt="pin" />
</AdvancedMarker>
```

Removing `anchorTop` or supplying both sides avoids the crash. This matches the reporter's findings ("removing the prop doesn't cause the crash", "in a closed environment it works").

## Changes

- `src/components/advanced-marker.tsx`: guard the two assignments so each runs only when the corresponding prop was provided by the consumer.
- `src/components/__tests__/advanced-marker.test.tsx`: regression test verifying the unprovided anchor side has no own-property descriptor after rendering.

## Test

- `npx jest` → 20 suites passed, 157 tests passed (plus pre-existing todos unrelated to this change).
- `npx tsc --project tsconfig.test.json --noEmit` → exit 0.
- `npx eslint` / `prettier --check` on changed files → clean.

## Notes for reviewer

- The full crash only manifests with the real Google Maps JS API + `draggable`; the jest-mocks backend cannot reproduce the `appendChild` TypeError. The regression test therefore locks the deterministic root-cause invariant: after rendering with only `anchorTop`, the marker must not own an `anchorLeft` property (on `main` this assertion fails with `value: undefined`).
- Known limitation: dynamically *removing* a previously provided anchor prop now leaves the previous value in place until the marker is rebuilt (map/library/children changes rebuild the instance). On `main` that same scenario writes `undefined` — the crash form this PR fixes — so neither version implements a reset-to-default semantic; remount if a reset is needed.
- Related: `src/components/3d/marker.tsx` (`Marker3D`) has the same unconditional-assignment pattern via `usePropBinding`; left out of this focused fix — happy to file a follow-up.