### PR TITLE
docs: fix two broken links in README (license badge, docs reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Components for the Google Maps JavaScript API
 
-[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/visgl/react-google-maps/tree/main/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/visgl/react-google-maps/blob/main/LICENSE.md)
 
 This is a TypeScript / JavaScript library to integrate the Maps JavaScript API
 into your React application.
@@ -260,7 +260,7 @@ You can also discuss this library on [our Discord server][gmp-discord].
 [api-polygon]: https://visgl.github.io/react-google-maps/docs/api-reference/components/polygon
 [api-map-3d]: https://visgl.github.io/react-google-maps/docs/api-reference/components/map-3d
 [api-use-lib]: https://visgl.github.io/react-google-maps/docs/api-reference/hooks/use-maps-library
-[docs]: https://visgl.github.io/react-google-maps/docs/
+[docs]: https://visgl.github.io/react-google-maps/docs
 [examples]: https://visgl.github.io/react-google-maps/examples
 [gmp-services]: https://developers.google.com/maps/documentation/javascript#services
 [gmp-libraries]: https://developers.google.com/maps/documentation/javascript/libraries


### PR DESCRIPTION
Two links in the root `README.md` currently return hard 404s. This PR fixes both; the diff is two lines and touches nothing else.

## 1. MIT License badge (line 3)

The badge links to `/tree/main/LICENSE`, but the repository's only license file is `LICENSE.md` — there is no path named `LICENSE`, so the badge 404s.

```
-](https://github.com/visgl/react-google-maps/tree/main/LICENSE)
+](https://github.com/visgl/react-google-maps/blob/main/LICENSE.md)
```

This is a missing file, not a `/tree/` vs `/blob/` quirk — GitHub happily resolves tree paths for files that exist:

```
$ curl -sSL -o /dev/null -w 'final=%{url_effective} code=%{http_code} redirects=%{num_redirects}\n' \
    https://github.com/visgl/react-google-maps/tree/main/LICENSE.md
final=https://github.com/visgl/react-google-maps/blob/main/LICENSE.md code=200 redirects=1

$ for f in LICENSE LICENSE.md LICENCE license; do
    printf '%s  raw .../main/%s\n' "$(curl -sS -o /dev/null -w '%{http_code}' \
      https://raw.githubusercontent.com/visgl/react-google-maps/main/$f)" "$f"; done
404  raw .../main/LICENSE
200  raw .../main/LICENSE.md
404  raw .../main/LICENCE
404  raw .../main/license
```

## 2. `[docs]` link reference (line 263)

This is the target of "Please see our [documentation][docs]" on line 66. It carries a trailing slash that the site does not serve.

```
-[docs]: https://visgl.github.io/react-google-maps/docs/
+[docs]: https://visgl.github.io/react-google-maps/docs
```

The root cause is the site's own deliberate configuration — `website/docusaurus.config.js:18` sets `trailingSlash: false`, so the build emits no `/docs/index.html` and the trailing-slash form falls through to the Docusaurus 404 route:

```
$ grep -n 'trailingSlash' website/docusaurus.config.js
18:  trailingSlash: false,

$ curl -sSL .../docs  | grep -o '<title[^>]*>[^<]*</title>'   # -> Introduction | React Google Maps
$ curl -sSL .../docs/ | grep -o '<title[^>]*>[^<]*</title>'   # -> Page Not Found | React Google Maps
```

Line 263 was also the only trailing-slash `visgl.github.io` URL in the whole README (`grep -cE '.../[^ ]*/$' README.md` → `1`); the ten `[api-*]` definitions above it and `[examples]` below it already omit it and all resolve.

## Verification

Status codes before → after, run against the live site:

```
404  https://github.com/visgl/react-google-maps/tree/main/LICENSE     (old)
200  https://github.com/visgl/react-google-maps/blob/main/LICENSE.md  (new)
404  https://visgl.github.io/react-google-maps/docs/                  (old)
200  https://visgl.github.io/react-google-maps/docs                   (new)
```

The two 200s are real pages, not soft-404s — see the `<title>` check above. Both replacement URLs were re-extracted from the edited `README.md` and curled again to confirm they are exactly what the file now contains.

## Checklist notes

- **Tests** — not run. `test:prettier` checks `./src ./examples` and `test:linter` checks `src/**`, so a root-`README.md`-only change is outside the suite's scope entirely; `test:tsc` and `test:unit` are likewise unaffected. Happy to run the full suite if you'd like it on the record.
- **Documentation** — no public API added or modified, so no `docs/api-reference`, `upgrade-guide.md` or `whats-new.md` changes are needed.
- **Related issue** — none open that I could find; this was spotted by link-checking the README.
- **Milestone** — I can't set labels or milestones on this repo; please apply whichever is appropriate.

## Limitation

For defect 2 you could alternatively make the site serve `/docs/`, but since `trailingSlash: false` is an intentional setting, the README is the aligned side to change. I deliberately did **not** rename `LICENSE.md`, which would be a larger unrequested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
